### PR TITLE
add burner account for skipped login screen

### DIFF
--- a/Web3Unity/Scripts/Scenes/WebLogin.cs
+++ b/Web3Unity/Scripts/Scenes/WebLogin.cs
@@ -42,7 +42,7 @@ public class WebLogin : MonoBehaviour
     public void OnSkip()
     {
         // burner account for skipped sign in screen
-        PlayerPrefs.SetString("Account", "0x0000000000000000000000000000000000000000");
+        PlayerPrefs.SetString("Account", "");
         // move to next scene
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
     }


### PR DESCRIPTION
Adds burner account to PlayerPrefs if the user opts to not log in.