### PR TITLE
Converting Pointer_stringify calls to UTF8ToString in .jslib

### DIFF
--- a/Web3Unity/Scripts/Library/WebGL/web3gl.jslib
+++ b/Web3Unity/Scripts/Library/WebGL/web3gl.jslib
@@ -16,13 +16,13 @@ mergeInto(LibraryManager.library, {
 
   SendContractJs: function (method, abi, contract, args, value, gasLimit, gasPrice) {
     window.web3gl.sendContract(
-      Pointer_stringify(method),
-      Pointer_stringify(abi),
-      Pointer_stringify(contract),
-      Pointer_stringify(args),
-      Pointer_stringify(value),
-      Pointer_stringify(gasLimit),
-      Pointer_stringify(gasPrice)
+      UTF8ToString(method),
+      UTF8ToString(abi),
+      UTF8ToString(contract),
+      UTF8ToString(args),
+      UTF8ToString(value),
+      UTF8ToString(gasLimit),
+      UTF8ToString(gasPrice)
     );
   },
 
@@ -41,20 +41,20 @@ mergeInto(LibraryManager.library, {
 
   SendTransactionJs: function (to, value, gasLimit, gasPrice) {
     window.web3gl.sendTransaction(
-      Pointer_stringify(to),
-      Pointer_stringify(value),
-      Pointer_stringify(gasLimit),
-      Pointer_stringify(gasPrice)
+      UTF8ToString(to),
+      UTF8ToString(value),
+      UTF8ToString(gasLimit),
+      UTF8ToString(gasPrice)
     );
   },
 
     SendTransactionJsData: function (to, value, gasLimit, gasPrice, data) {
     window.web3gl.sendTransactionData(
-      Pointer_stringify(to),
-      Pointer_stringify(value),
-      Pointer_stringify(gasLimit),
-      Pointer_stringify(gasPrice),
-      Pointer_stringify(data)
+      UTF8ToString(to),
+      UTF8ToString(value),
+      UTF8ToString(gasLimit),
+      UTF8ToString(gasPrice),
+      UTF8ToString(data)
     );
   },
 
@@ -74,11 +74,11 @@ mergeInto(LibraryManager.library, {
   },
 
   SignMessage: function (message) {
-    window.web3gl.signMessage(Pointer_stringify(message));
+    window.web3gl.signMessage(UTF8ToString(message));
   },
 
   HashMessage: function (message) {
-    window.web3gl.sha3Message(Pointer_stringify(message));
+    window.web3gl.sha3Message(UTF8ToString(message));
   },
 
   SignMessageResponse: function () {


### PR DESCRIPTION
Just updated the .jslib file from `Pointer_stringify` to `UTF8ToString`

Not sure if this breaks backwards compatibility.  Here's a link I found in the Unity documents:

No deep link... search for "WebGL: Updated Emscripten to 2.0.19"
https://docs.unity3d.com/2021.2/Documentation/Manual/UpgradeGuide20212.html

This resolves [issue 208](https://github.com/ChainSafe/web3.unity/issues/208).