### PR TITLE
Bugfix #531 iOS Constructor Missing

### DIFF
--- a/src/ChainSafe.GamingSdk.EVM.Unity/ChainSafe.GamingSdk.EVM.Unity.csproj
+++ b/src/ChainSafe.GamingSdk.EVM.Unity/ChainSafe.GamingSdk.EVM.Unity.csproj
@@ -25,5 +25,11 @@
     <!-- Resolve dependency conflict by referencing this version directly -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="link.xml">
+      <LogicalName>ChainSafe.GamingSdk.EVM.Unity.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 
 </Project>

--- a/src/ChainSafe.GamingSdk.EVM.Unity/link.xml
+++ b/src/ChainSafe.GamingSdk.EVM.Unity/link.xml
@@ -1,0 +1,33 @@
+﻿<linker>
+    <!--This is required to avoid code stripping by Unity.
+    Types that are instantiated using DI (therefore reflection)
+    are not getting registered by the static code analyzer-->
+    
+    <!--TODO: would be great to have this automated,
+    possibly by using custom attributes and post-build link.xml generation-->
+    
+    <assembly fullname="ChainSafe.GamingSDK.EVM">
+        <type fullname="ChainSafe.GamingWeb3.Analytics.ApiAnalyticsClient" preserve="all"/>
+        <type fullname="ChainSafe.GamingWeb3.Analytics.NoOpAnalyticsClient" preserve="all"/>
+        <type fullname="Web3Unity.Scripts.Library.Ethers.ChainProvider" preserve="all"/>
+        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.EventPoller" preserve="all"/>
+        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProvider" preserve="all"/>
+    </assembly>
+    <assembly fullname="ChainSafe.GamingSdk.EVM.Unity">
+        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityDispatcherAdapter" preserve="all"/>
+        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityHttpClient" preserve="all"/>
+        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityLogWriter" preserve="all"/>
+        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityOperatingSystemMediator" preserve="all"/>
+    </assembly>
+    <assembly fullname="ChainSafe.GamingSDK.EVM.WebPageWallet">
+        <type fullname="ChainSafe.GamingSDK.EVM.MetaMaskBrowserWallet.WebPageWallet" preserve="all"/>
+    </assembly>
+    <assembly fullname="ChainSafe.GamingSdk.Gelato">
+        <type fullname="ChainSafe.GamingSdk.Gelato.Gelato" preserve="all"/>
+    </assembly>
+    
+    <!--Assemblies from UnityPackages-->
+    <assembly fullname="chainsafe.web3-unity">
+        <type fullname="ChainSafe.GamingSDK.EVM.WebGLWallet.WebGLWallet" preserve="all"/>
+    </assembly>
+</linker>

--- a/src/ChainSafe.GamingSdk.EVM.Unity/link.xml
+++ b/src/ChainSafe.GamingSdk.EVM.Unity/link.xml
@@ -1,33 +1,37 @@
 ﻿<linker>
-    <!--This is required to avoid code stripping by Unity.
+    <!--
+    This is required to avoid code stripping by Unity.
     Types that are instantiated using DI (therefore reflection)
-    are not getting registered by the static code analyzer-->
+    are not getting registered by the static code analyzer
     
-    <!--TODO: would be great to have this automated,
-    possibly by using custom attributes and post-build link.xml generation-->
+    Also all default constructors are getting removed,
+    so DTO deserialization doesn't work.
+    -->
     
-    <assembly fullname="ChainSafe.GamingSDK.EVM">
-        <type fullname="ChainSafe.GamingWeb3.Analytics.ApiAnalyticsClient" preserve="all"/>
-        <type fullname="ChainSafe.GamingWeb3.Analytics.NoOpAnalyticsClient" preserve="all"/>
-        <type fullname="Web3Unity.Scripts.Library.Ethers.ChainProvider" preserve="all"/>
-        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.EventPoller" preserve="all"/>
-        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProvider" preserve="all"/>
-    </assembly>
-    <assembly fullname="ChainSafe.GamingSdk.EVM.Unity">
-        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityDispatcherAdapter" preserve="all"/>
-        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityHttpClient" preserve="all"/>
-        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityLogWriter" preserve="all"/>
-        <type fullname="ChainSafe.GamingSdk.Evm.Unity.UnityOperatingSystemMediator" preserve="all"/>
-    </assembly>
-    <assembly fullname="ChainSafe.GamingSDK.EVM.WebPageWallet">
-        <type fullname="ChainSafe.GamingSDK.EVM.MetaMaskBrowserWallet.WebPageWallet" preserve="all"/>
-    </assembly>
-    <assembly fullname="ChainSafe.GamingSdk.Gelato">
-        <type fullname="ChainSafe.GamingSdk.Gelato.Gelato" preserve="all"/>
-    </assembly>
+    <!--
+    TODO: would be great to have this automated,
+    possibly by using custom attributes and post-build link.xml generation
+    -->
     
-    <!--Assemblies from UnityPackages-->
-    <assembly fullname="chainsafe.web3-unity">
-        <type fullname="ChainSafe.GamingSDK.EVM.WebGLWallet.WebGLWallet" preserve="all"/>
-    </assembly>
+    <!-- Our assemblies -->
+    <assembly fullname="ChainSafe.GamingSDK.EVM"/>
+    <assembly fullname="ChainSafe.GamingSdk.EVM.Unity"/>
+    <assembly fullname="ChainSafe.GamingSDK.EVM.WebPageWallet"/>
+    <assembly fullname="ChainSafe.GamingSdk.Gelato"/>
+
+    <!-- Dependencies -->
+    <assembly fullname="BouncyCastle.Crypto"/>
+    <assembly fullname="Nethereum.ABI"/>
+    <assembly fullname="Nethereum.Hex"/>
+    <assembly fullname="Nethereum.JsonRpc.Client"/>
+    <assembly fullname="Nethereum.Merkle.Patricia"/>
+    <assembly fullname="Nethereum.Model"/>
+    <assembly fullname="Nethereum.RLP"/>
+    <assembly fullname="Nethereum.RPC"/>
+    <assembly fullname="Nethereum.Signer"/>
+    <assembly fullname="Nethereum.Util"/>
+    <assembly fullname="NBitcoin"/>
+    
+    <!-- Assemblies from UnityPackages -->
+    <assembly fullname="chainsafe.web3-unity"/>
 </linker>

--- a/src/UnityPackages/.gitignore
+++ b/src/UnityPackages/.gitignore
@@ -79,8 +79,8 @@ crashlytics-build.properties
 !*.meta
 
 # Ignore the build artifacts from our libraries
-/io.chainsafe.web3-unity/Runtime/Libraries
-/io.chainsafe.web3-unity/Runtime/Libraries.meta
+/io.chainsafe.web3-unity/Runtime/Libraries/*.dll
+/io.chainsafe.web3-unity/Runtime/Libraries/*.dll.meta
 
 # Since the folder is called 'Debug', it's being ignored, so negate that
 !/io.chainsafe.web3-unity/Runtime/Plugins/Web3AuthSDK/Debug

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries.meta
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de66600a6d2f6bd4c8342b439e1415ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml
@@ -1,0 +1,7 @@
+﻿<linker>
+    <assembly fullname="ChainSafe.GamingSDK.EVM">
+        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProvider">
+            <method signature="System.Void .ctor(Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProviderConfig, ChainSafe.GamingWeb3.Environment.Web3Environment, Web3Unity.Scripts.Library.Ethers.ChainProvider, ChainSafe.GamingWeb3.IChainConfig)"/>
+        </type>
+    </assembly>
+</linker>

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml.meta
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3f20f802b0664923b7fab2497eaedeab
+timeCreated: 1691487373

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/WebGLWallet.cs
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/WebGLWallet.cs
@@ -189,7 +189,7 @@ namespace ChainSafe.GamingSDK.EVM.WebGLWallet
             throw new NotImplementedException();
         }
 
-        public Task<string> SignTypedData(Domain domain, Dictionary<string, MemberDescription[]> types, MemberValue[] message)
+        public Task<string> SignTypedData<TStructType>(SerializableDomain domain, Dictionary<string, MemberDescription[]> types, TStructType message)
         {
             throw new NotImplementedException();
         }

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/link.xml
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/link.xml
@@ -1,0 +1,8 @@
+﻿<linker>
+    <assembly fullname="chainsafe.web3-unity">
+        <type fullname="ChainSafe.GamingSDK.EVM.WebGLWallet.WebGLWallet" ignoreIfMissing="1">
+            <method signature="System.Void .ctor()"/>
+            <method signature="System.Void .ctor(Web3Unity.Scripts.Library.Ethers.Providers.IRpcProvider)"/>
+        </type>
+    </assembly>
+</linker>

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/link.xml.meta
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/link.xml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 99f5cfe55cc245e78d5ee7979403a565
+timeCreated: 1691486816


### PR DESCRIPTION
The problem was caused by Unity's stripping procedure.
Had to add **All our assemblies + Nethereum + NBitcoin + BouncyCastle** to the list of assemblies that will be ignored during the code stripping procedure.

This is done by adding a link.xml file to one of the projects and marking it as an embedded resource.

No matter what Stripping Level user chooses in his project settings, the code will still be there after the build is completed (Didn't test other levels though).