### PR TITLE
#535 Android build broken

### DIFF
--- a/src/UnityPackages/io.chainsafe.web3-unity.web3auth/Editor/chainsafe.web3-unity.web3auth.Editor.asmdef
+++ b/src/UnityPackages/io.chainsafe.web3-unity.web3auth/Editor/chainsafe.web3-unity.web3auth.Editor.asmdef
@@ -2,7 +2,9 @@
     "name": "chainsafe.web3-unity.web3auth.Editor",
     "rootNamespace": "",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml
@@ -1,7 +1,0 @@
-﻿<linker>
-    <assembly fullname="ChainSafe.GamingSDK.EVM">
-        <type fullname="Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProvider">
-            <method signature="System.Void .ctor(Web3Unity.Scripts.Library.Ethers.Providers.JsonRpcProviderConfig, ChainSafe.GamingWeb3.Environment.Web3Environment, Web3Unity.Scripts.Library.Ethers.ChainProvider, ChainSafe.GamingWeb3.IChainConfig)"/>
-        </type>
-    </assembly>
-</linker>

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml.meta
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Libraries/link.xml.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 3f20f802b0664923b7fab2497eaedeab
-timeCreated: 1691487373

--- a/src/UnitySampleProject/ProjectSettings/BurstAotSettings_Android.json
+++ b/src/UnitySampleProject/ProjectSettings/BurstAotSettings_Android.json
@@ -1,0 +1,14 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "OptimizeFor": 0
+  }
+}

--- a/src/UnitySampleProject/ProjectSettings/ProjectSettings.asset
+++ b/src/UnitySampleProject/ProjectSettings/ProjectSettings.asset
@@ -245,7 +245,7 @@ PlayerSettings:
   useCustomBaseGradleTemplate: 0
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
-  AndroidTargetArchitectures: 1
+  AndroidTargetArchitectures: 2
   AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -671,7 +671,8 @@ PlayerSettings:
   scriptingDefineSymbols: {}
   additionalCompilerArguments: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Android: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel:
     EmbeddedLinux: 1


### PR DESCRIPTION
This PR fixes the Android build procedure.
There was a problem with `chainsafe.web3-unity.web3auth.Editor.asmdef` configuration inside `io.chainsafe.web3-unity.web3auth`.
Now it's gone.

The problem described in the task description is probably just an Android tools installation issue. So this PR actually fixes a different build bug than described in the ticket.