### PR TITLE
Removing resources folder creation

### DIFF
--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/ProjectConfigUtilities.cs
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/ProjectConfigUtilities.cs
@@ -17,7 +17,6 @@ public static class ProjectConfigUtilities
         if (projectConfig == null)
         {
             projectConfig = ScriptableObject.CreateInstance<ProjectConfigScriptableObject>();
-            UnityEditor.AssetDatabase.CreateFolder("Assets", "Resources");
             UnityEditor.AssetDatabase.CreateAsset(projectConfig, "Assets/Resources/ProjectConfigData.asset");
         }
 


### PR DESCRIPTION
Removal of the resources folder being created so it doesn't create an empty folder seeing as we already have it there for web3auth now.