### PR TITLE
Warning cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-ae3ec74234fe30a88279b3850c99ff191f373781
         
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v3

--- a/src/ChainSafe.GamingSDK.EVM.Tests/Node/Emulator.cs
+++ b/src/ChainSafe.GamingSDK.EVM.Tests/Node/Emulator.cs
@@ -29,8 +29,8 @@ namespace ChainSafe.GamingSDK.EVM.Tests.Node
                 throw new Web3Exception("Anvil is not starting");
             }
 
-            // Wait 2 seconds since it's hard to figure out when anvil finish starting
-            Thread.Sleep(2000);
+            // Wait 3 seconds since it's hard to figure out when anvil finish starting
+            Thread.Sleep(3000);
 
             return anvil;
         }

--- a/src/UnityPackages/io.chainsafe.web3-unity/Editor/Startup.cs
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Editor/Startup.cs
@@ -54,9 +54,7 @@ namespace ChainSafe.GamingSdk.Editor
             try
             {
                 var projectID = ProjectConfigUtilities.Load()?.ProjectId;
-                if (
-                    string.IsNullOrEmpty(projectID) ||
-                    !await ChainSafeServerSettings.ValidateProjectIDAsync(projectID))
+                if (string.IsNullOrEmpty(projectID))
                 {
                     ChainSafeServerSettings.ShowWindow();
                 }

--- a/src/UnitySampleProject/Assets/Scripts/Scenes/Login.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Scenes/Login.cs
@@ -74,7 +74,7 @@ namespace Scenes
             }
         }
 
-        private void TryAutoLogin()
+        private async void TryAutoLogin()
         {
             if (!useWebPageWallet)
                 return;
@@ -97,7 +97,7 @@ namespace Scenes
                         });
                 });
 
-            ProcessLogin(web3Builder);
+            await ProcessLogin(web3Builder);
         }
 
         private async void LoginWithExistingAccount()
@@ -129,7 +129,7 @@ namespace Scenes
             }
         }
 
-        private void LoginWithWeb3Auth(Provider provider)
+        private async void LoginWithWeb3Auth(Provider provider)
         {
             var web3Builder = new Web3Builder(ProjectConfigUtilities.Load())
                 .Configure(ConfigureCommonServices)
@@ -155,7 +155,7 @@ namespace Scenes
                     services.UseWeb3AuthWallet(web3AuthConfig);
                 });
 
-            ProcessLogin(web3Builder);
+            await ProcessLogin(web3Builder);
         }
 
         private async Task ProcessLogin(Web3Builder builder)

--- a/src/UnitySampleProject/Assets/Scripts/Scenes/SampleMain/Unsorted/Sha3Behaviour.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Scenes/SampleMain/Unsorted/Sha3Behaviour.cs
@@ -15,11 +15,12 @@ namespace Samples.Behaviours.Unsorted
             logic = new UnsortedSample(Web3);
         }
 
-        protected override async Task ExecuteSample()
+        protected override Task ExecuteSample()
         {
             var hash = logic.Sha3(message);
 
             SampleOutputUtil.PrintResult(hash, nameof(UnsortedSample), nameof(UnsortedSample.Sha3));
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Fixes nunit tests, foundry version was the culprit. GJ on finding it Peter.

Fixes the project id web request on minor code changes as having this is rather annoying.

Fixes a few annoying editor warnings regarding the absence of await in async calls.

3 login warnings:
2 calls were async without an await in login.cs
1 call was async without an await, removed async & returned a task completion instead in sha3behaviour.cs

Login process seems fine my end.

I have another PR coming in on top of this one after to fix the nft texture but I figured I'd wait until this is in to keep some separation for readability.