### PR TITLE
Texture-fix

### DIFF
--- a/src/UnityPackages/io.chainsafe.web3-unity/Editor/Startup.cs
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Editor/Startup.cs
@@ -49,7 +49,7 @@ namespace ChainSafe.GamingSdk.Editor
             };
         }
 
-        static async void ValidateProjectID()
+        static void ValidateProjectID()
         {
             try
             {

--- a/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
+++ b/src/UnityPackages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
@@ -68,7 +68,7 @@ namespace Scripts.EVM.Token
             {
                 tokenId
             });
-            return contractData.ToString();
+            return contractData[0].ToString();
         }
 
     }

--- a/src/UnitySampleProject/Assets/Scenes/SampleImportNftTexture.unity
+++ b/src/UnitySampleProject/Assets/Scenes/SampleImportNftTexture.unity
@@ -549,8 +549,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b9bec61a12d447589906f16425c4258, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  contractAddress: 0x162BA1d478948e0ab2d4B21dca2471982C1Fb797
-  tokenId: 0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5
+  contractAddress: 0x0288B4F1389ED7b3d3f9C7B73d4408235c0CBbc6
+  tokenId: 0
   textureContainer: {fileID: 159726534}
 --- !u!114 &593227350
 MonoBehaviour:
@@ -1711,7 +1711,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 18.1
+  m_fontSize: 26
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/src/UnitySampleProject/Assets/Scenes/SampleMain.unity
+++ b/src/UnitySampleProject/Assets/Scenes/SampleMain.unity
@@ -3671,8 +3671,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ce73e85a6834bc2bfbd824e04cd5ec1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  contractAddress: 0x2c1867BC3026178A47a677513746DCc6822A137A
-  tokenId: 0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5
+  contractAddress: 0x0288B4F1389ED7b3d3f9C7B73d4408235c0CBbc6
+  tokenId: 0
 --- !u!114 &963882744
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/src/UnitySampleProject/Assets/Scripts/Samples/ERC1155/ImportNFTTextureExample.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Samples/ERC1155/ImportNFTTextureExample.cs
@@ -11,8 +11,8 @@ public class ImportNFTTextureExample : MonoBehaviour
 
     async void Start()
     {
-        string contract = "0x162BA1d478948e0ab2d4B21dca2471982C1Fb797"; // gitleaks:allow
-        string tokenId = "0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5"; // gitleaks:allow
+        string contract = "0x0288B4F1389ED7b3d3f9C7B73d4408235c0CBbc6";
+        string tokenId = "0";
 
         // fetch uri from chain
         string uri = await Erc1155.URI(Web3Accessor.Web3, contract, tokenId);

--- a/src/UnitySampleProject/Assets/Scripts/Samples/Erc1155Sample.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Samples/Erc1155Sample.cs
@@ -15,7 +15,7 @@ namespace Web3Unity.Scripts.Prefabs
 {
     public class NftMetaDataSample
     {
-        public string ImageUri { get; set; }
+        public string image { get; set; }
     }
 
     public class Erc1155Sample
@@ -57,7 +57,7 @@ namespace Web3Unity.Scripts.Prefabs
             var metaData = await DownloadMetaData();
 
             // unpack image URI if IPFS
-            var imageUri = metaData.ImageUri;
+            var imageUri = metaData.image;
             imageUri = UnpackUriIfIpfs(imageUri);
 
             // download texture

--- a/src/UnitySampleProject/Assets/Scripts/Samples/GelatoSample.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Samples/GelatoSample.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using ChainSafe.GamingSdk.Gelato;
 using ChainSafe.GamingSdk.Gelato.Dto;
 using ChainSafe.GamingWeb3;
+using UnityEngine;
 
 public class GelatoSample
 {

--- a/src/UnitySampleProject/Assets/Scripts/Scenes/SampleNftTexture/Erc1155ImportNftTextureBehaviour.cs
+++ b/src/UnitySampleProject/Assets/Scripts/Scenes/SampleNftTexture/Erc1155ImportNftTextureBehaviour.cs
@@ -8,8 +8,8 @@ namespace Scenes.SampleNftTexture
 {
     public class Erc1155ImportNftTextureBehaviour : SampleBehaviour
     {
-        public string contractAddress = "0x162BA1d478948e0ab2d4B21dca2471982C1Fb797"; // gitleaks:allow
-        public string tokenId = "0x01559ae4021aee70424836ca173b6a4e647287d15cee8ac42d8c2d8d128927e5"; // gitleaks:allow
+        public string contractAddress = "0x0288B4F1389ED7b3d3f9C7B73d4408235c0CBbc6";
+        public string tokenId = "0";
 
         public RawImage textureContainer;
 


### PR DESCRIPTION
URI-call updated so it doesn't point to empty metadata.
Texture call updated and working. Closes #566 
Texture was deserializing to a class with the key "ImageUri", altered as this should be "image" following metadata standards.
Both scripts and prefab metadata for the above are updated also.
Another empty async call removed (left behind previously).
Unity engine import added geleto to script to enable webgl boot as Time.time was showing as missing a reference without it.