### PR TITLE
Gelato content disable

### DIFF
--- a/src/ChainSafe.GamingSdk.Gelato/Gelato.cs
+++ b/src/ChainSafe.GamingSdk.Gelato/Gelato.cs
@@ -22,6 +22,7 @@ namespace ChainSafe.GamingSdk.Gelato
         private readonly ISigner signer;
         private readonly GelatoConfig config;
         private readonly IChainConfig chainConfig;
+        private bool gelatoDisabled;
 
         public const string SponsoredCallErc2771TypeName = "SponsoredCallERC2771";
         public const string CallWithSyncFeeErc2771TypeName = "CallWithSyncFeeERC2771";
@@ -47,9 +48,11 @@ namespace ChainSafe.GamingSdk.Gelato
         {
             if (!await IsNetworkSupported(chainConfig.ChainId))
             {
-                throw new Web3Exception("network not supported by Gelato");
+                gelatoDisabled = true;
             }
         }
+
+        public bool GetGelatoDisabled() => gelatoDisabled;
 
         public ValueTask WillStopAsync() => new(Task.CompletedTask);
 

--- a/src/ChainSafe.GamingSdk.Gelato/Types/IGelato.cs
+++ b/src/ChainSafe.GamingSdk.Gelato/Types/IGelato.cs
@@ -31,5 +31,7 @@ namespace ChainSafe.GamingSdk.Gelato.Types
         Task<RelayedTask> GetTaskStatus(string taskId);
 
         Task<string[]> GetPaymentTokens();
+
+        bool GetGelatoDisabled();
     }
 }

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scenes/SampleMain.unity
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scenes/SampleMain.unity
@@ -4020,6 +4020,63 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &1019211779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 98914093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f404484bf3c7d4246a08e60ab1cd69b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gelatoObj: {fileID: 98914093}
+--- !u!114 &1019211780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 98914093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1031869231
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Samples/GelatoSample.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Samples/GelatoSample.cs
@@ -190,7 +190,7 @@ public class GelatoSample
             }
         }
     }
-    
+
     public bool GetGelatoDisabled()
     {
         return _web3.Gelato().GetGelatoDisabled();

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Samples/GelatoSample.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Samples/GelatoSample.cs
@@ -190,6 +190,11 @@ public class GelatoSample
             }
         }
     }
+    
+    public bool GetGelatoDisabled()
+    {
+        return _web3.Gelato().GetGelatoDisabled();
+    }
 
     async Task WaitForSeconds(int seconds)
     {

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Scenes/SampleMain/Gelato/GelatoDisableContent.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Scenes/SampleMain/Gelato/GelatoDisableContent.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+
+namespace Samples.Behaviours.Gelato
+{
+    public class GelatoDisableContent : SampleBehaviour
+    {
+        private GelatoSample logic;
+
+        protected override void Awake()
+        {
+            base.Awake();
+            logic = new GelatoSample(Web3);
+            ExecuteSample();
+        }
+
+        protected override Task ExecuteSample()
+        {
+            if (!logic.GetGelatoDisabled()) return Task.CompletedTask;
+            print("Gelato functionality disabled as your chain isn't supported");
+            gameObject.SetActive(false);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Scenes/SampleMain/Gelato/GelatoDisableContent.cs.meta
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0-pre001/Web3.Unity Samples/Scripts/Scenes/SampleMain/Gelato/GelatoDisableContent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f404484bf3c7d4246a08e60ab1cd69b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Content disabled for gelato when an unsupported chain is used i.e cronos and allows alternate chains to be logged in, closes #585 

![image](https://github.com/ChainSafe/web3.unity/assets/57473220/4686e7e9-779e-466c-ac3e-35b466118fb0)
