### PR TITLE
Update Web3Auth package.json version

### DIFF
--- a/Packages/io.chainsafe.web3-unity.web3auth/package.json
+++ b/Packages/io.chainsafe.web3-unity.web3auth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "io.chainsafe.web3-unity.web3auth",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "displayName": "web3.unity SDK Web3Auth integration",
     "description": "web3.unity is an open-source gaming SDK written in C# and developed by ChainSafe Gaming. It connects games built in the Unity game engine to the blockchain. The library currently supports games built for web browsers (WebGL), iOS/Android mobile, and desktop. web3.unity is compatible with most EVM-based chains such as Ethereum, Polygon, Moonbeam, Cronos, Nervos, and Binance Smart Chain, letting developers easily choose and switch between them to create the best in-game experience.",
     "license": "LGPL-3.0-only",


### PR DESCRIPTION
This PR fixes failed build on OpenUPM side.
https://dev.azure.com/openupm/openupm/_build/results?view=logs&buildId=35658&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9

According to OpenUPM docs new build should be picked up automatically.
https://openupm.com/docs/adding-upm-package.html#handling-failed-builds