### PR TITLE
Goerli Exception

### DIFF
--- a/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Web3AuthWalletExtensions.cs
+++ b/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Web3AuthWalletExtensions.cs
@@ -47,7 +47,7 @@ public static class Web3AuthWalletExtensions
     /// <returns>The modified IWeb3ServiceCollection with the Web3AuthWallet configuration replaced.</returns>
     public static IWeb3ServiceCollection ConfigureWeb3AuthWallet(this IWeb3ServiceCollection collection, Web3AuthWalletConfig configuration)
     {
-        collection.Replace(ServiceDescriptor.Singleton(typeof(Web3AuthWalletConfig), configuration);
+        collection.Replace(ServiceDescriptor.Singleton(typeof(Web3AuthWalletConfig), configuration));
         return collection;
     }
 }

--- a/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scenes/SampleMain.unity
+++ b/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scenes/SampleMain.unity
@@ -1509,7 +1509,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 37375165}
   m_Direction: 0
   m_Value: 0
-  m_Size: 0.47125128
+  m_Size: 0.24156472
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -6726,6 +6726,50 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &1764495626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1764495628}
+  - component: {fileID: 1764495627}
+  m_Layer: 0
+  m_Name: GoerliCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1764495627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764495626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f180489f7a552ad4c98731cb95b99f08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1764495628
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764495626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -35.540485, y: -78.78714, z: -4.2523}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1800123346
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs
+++ b/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs
@@ -1,5 +1,6 @@
 using System;
 using ChainSafe.Gaming.UnityPackage;
+using ChainSafe.Gaming.Web3;
 using UnityEngine;
 
 public class GoerliCheck : MonoBehaviour
@@ -8,7 +9,7 @@ public class GoerliCheck : MonoBehaviour
     {
         if (Web3Accessor.Web3.ChainConfig.ChainId != "5")
         {
-            throw new SystemException("Please set your chain to Goerli to see the examples functioning correctly");
+            throw new Web3Exception("Please set your chain to Goerli to see the examples functioning correctly");
         }
     }
 }

--- a/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs
+++ b/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs
@@ -1,0 +1,14 @@
+using System;
+using ChainSafe.Gaming.UnityPackage;
+using UnityEngine;
+
+public class GoerliCheck : MonoBehaviour
+{
+    void Start()
+    {
+        if (Web3Accessor.Web3.ChainConfig.ChainId != "5")
+        {
+            throw new SystemException("Please set your chain to Goerli to see the examples functioning correctly");
+        }
+    }
+}

--- a/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs.meta
+++ b/Packages/io.chainsafe.web3-unity/Samples~/Web3.Unity/Scripts/Scenes/SampleMain/GoerliCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f180489f7a552ad4c98731cb95b99f08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scenes/SampleMain.unity
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scenes/SampleMain.unity
@@ -1509,7 +1509,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 37375165}
   m_Direction: 0
   m_Value: 0
-  m_Size: 0.47125128
+  m_Size: 0.24156472
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -6726,6 +6726,50 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &1764495626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1764495628}
+  - component: {fileID: 1764495627}
+  m_Layer: 0
+  m_Name: GoerliCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1764495627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764495626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f180489f7a552ad4c98731cb95b99f08, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1764495628
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1764495626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -35.540485, y: -78.78714, z: -4.2523}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1800123346
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs
@@ -1,5 +1,6 @@
 using System;
 using ChainSafe.Gaming.UnityPackage;
+using ChainSafe.Gaming.Web3;
 using UnityEngine;
 
 public class GoerliCheck : MonoBehaviour
@@ -8,7 +9,7 @@ public class GoerliCheck : MonoBehaviour
     {
         if (Web3Accessor.Web3.ChainConfig.ChainId != "5")
         {
-            throw new SystemException("Please set your chain to Goerli to see the examples functioning correctly");
+            throw new Web3Exception("Please set your chain to Goerli to see the examples functioning correctly");
         }
     }
 }

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs
@@ -1,0 +1,14 @@
+using System;
+using ChainSafe.Gaming.UnityPackage;
+using UnityEngine;
+
+public class GoerliCheck : MonoBehaviour
+{
+    void Start()
+    {
+        if (Web3Accessor.Web3.ChainConfig.ChainId != "5")
+        {
+            throw new SystemException("Please set your chain to Goerli to see the examples functioning correctly");
+        }
+    }
+}

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs.meta
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/GoerliCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f180489f7a552ad4c98731cb95b99f08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A simple check on the sample scene that throws an exception informing the user that they need to be on the goerli chain to see the examples functioning. Closes #649

I've placed the script on an object in the root of the sample main scenes object hierarchy. I didn't want to put the check on the sample scripts or in the behavior as we would just be creating more code for the user to edit come development time.

To test, simply login to the samples main area on a chain that isn't goerli and you should see an error.