### PR TITLE
Replace `workflow_run` with `Workflow_call` [Merge First]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,7 @@
 name: CodeQL Workflow
 
 on:
-  workflow_run:
-    workflows: [ "Test Unity Package Workflow" ]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/duplicate_samples.yml
+++ b/.github/workflows/duplicate_samples.yml
@@ -1,8 +1,7 @@
 name: Duplicate Packages Samples Workflow
 
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_call:
 
 jobs:
   duplicate:

--- a/.github/workflows/pre_pull_request_checks.yml
+++ b/.github/workflows/pre_pull_request_checks.yml
@@ -1,0 +1,27 @@
+name: Merge Checks
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  duplicate_samples:
+    name: Duplicate Samples
+    uses: ChainSafe/web3.unity/.github/workflows/duplicate_samples.yml@main
+  publish_dependencies:
+    name: Publish Dependencies
+    uses: ChainSafe/web3.unity/.github/workflows/publish_dependencies.yml@main
+    needs: [duplicate_samples]
+  web3_tests:
+    name: Web3 Tests
+    uses: ChainSafe/web3.unity/.github/workflows/test.yaml@main
+    needs: [publish_dependencies]
+  unity_tests:
+    name: Unity Tests
+    uses: ChainSafe/web3.unity/.github/workflows/unity_tests.yml@main
+    needs: [web3_tests]
+    secrets: inherit
+  analyze_code:
+    name: Analyze Code
+    uses: ChainSafe/web3.unity/.github/workflows/codeql.yml@main
+    needs: [unity_tests]

--- a/.github/workflows/publish_dependencies.yml
+++ b/.github/workflows/publish_dependencies.yml
@@ -1,10 +1,7 @@
 name: Publish Solution Dependencies
 
 on:
-  workflow_run:
-    workflows: [ "Duplicate Packages Samples Workflow" ]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   publish:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,7 @@
 name: NUnit Tests Workflow
 
 on:
-  workflow_run:
-    workflows: [ "Publish Solution Dependencies" ]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   check:

--- a/.github/workflows/unity_tests.yml
+++ b/.github/workflows/unity_tests.yml
@@ -1,10 +1,7 @@
 name: Test Unity Package Workflow
 
 on:
-  workflow_run:
-    workflows: [ "NUnit Tests Workflow" ]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   testAllModes:


### PR DESCRIPTION
Use workflow_call instead of workflow_run to make sure checks are required for PRs
I've tested the workflow changes on this run https://github.com/ChainSafe/web3.unity/actions/runs/6733913117
![image](https://github.com/ChainSafe/web3.unity/assets/142783680/f06a95f6-8644-4c7a-a10f-0cff3b6e16a5)