### PR TITLE
Lootbox Login Fixes

### DIFF
--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scenes/SampleLogin.unity
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scenes/SampleLogin.unity
@@ -2675,6 +2675,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 96894e49d9863ec4db1d93a5e56f19cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  sceneToLoad: MainScene
   gelatoApiKey: 7MFQqyGS1Iui_e_MgmFW1BfbFeJ06g8nnL2oUTlIJug_
   errorPopup: {fileID: 1701305868}
   supportedWalletsDropdown: {fileID: 540464236}

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/Login.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/Login.cs
@@ -17,7 +17,7 @@ namespace Scenes
 {
     public abstract class Login : MonoBehaviour
     {
-        public const string MainSceneName = "SampleMain";
+        [SerializeField] public string sceneToLoad;
 
         public static int LoginSceneIndex { get; private set; } = 0;
 
@@ -58,7 +58,16 @@ namespace Scenes
 
             LoginSceneIndex = SceneManager.GetActiveScene().buildIndex;
 
-            SceneManager.LoadScene(MainSceneName);
+            // Attempt scene transition based on the login object sceneToLoad value
+            try
+            {
+                SceneManager.LoadScene(sceneToLoad);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
         }
 
         private void ConfigureCommonServices(IWeb3ServiceCollection services)

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Utilities/SceneIndexer.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Utilities/SceneIndexer.cs
@@ -21,7 +21,7 @@ public static class SceneIndexer
         TryAddEditorBuildSettingsScenes(PackageName, ScenesIndexedKey, new string[]
         {
             "SampleLogin.Unity",
-            $"{Login.MainSceneName}.Unity",
+            "SampleMain.Unity",
         });
     }
 


### PR DESCRIPTION
Created a public field with MainScene as the default value. Users can now alter this within the editor to specify their next scene choice. I'll also update the docs so they know to change this. This way lootboxes, sample scene and even custom scenes will work!

![image](https://github.com/ChainSafe/web3.unity/assets/57473220/52879f6c-b985-4677-8508-cec3b32aae5b)

---------------------To Test--------------------
Import the SDK as usual along with lootboxes.
Login to transition to the main scene to check that the default value functioning as intended.
Change the scene name value on the login object to the Lootboxes scene and check that the transitioning works.
Change the scene name value to a custom scene and check that transitioning works.