### PR TITLE
Tx hash fix

### DIFF
--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
@@ -109,7 +109,14 @@ namespace Scripts.EVM.Token
             const string method = EthMethod.Mint;
             var destination = await web3.Signer.GetAddress();
             var contract = web3.ContractBuilder.Build(abi, contractAddress);
-            return await contract.Send(method, new object[] { destination, id, amount, dataObject });
+            var response = await contract.Send(method, new object[]
+            {
+                destination,
+                id,
+                amount,
+                dataObject
+            });
+            return response;
         }
 
         /// <summary>

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
@@ -112,10 +112,10 @@ namespace Scripts.EVM.Token
         public static async Task<object[]> MintErc20(Web3 web3, string contractAddress, string toAccount, BigInteger amount)
         {
             const string method = EthMethod.Mint;
-            var destination = await web3.Signer.GetAddress();
             var contract = web3.ContractBuilder.Build(ABI.Erc20, contractAddress);
             var response = await contract.Send(method, new object[]
-            {   toAccount,
+            {
+                toAccount,
                 amount
             });
             return response;

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
@@ -114,7 +114,11 @@ namespace Scripts.EVM.Token
             const string method = EthMethod.Mint;
             var destination = await web3.Signer.GetAddress();
             var contract = web3.ContractBuilder.Build(ABI.Erc20, contractAddress);
-            return await contract.Send(method, new object[] { toAccount, amount });
+            var response = await contract.Send(method, new object[]
+            {   toAccount,
+                amount
+            });
+            return response;
         }
 
         /// <summary>

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc721.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc721.cs
@@ -7,6 +7,7 @@ using ChainSafe.Gaming.Web3;
 using Nethereum.Contracts.QueryHandlers.MultiCall;
 using Nethereum.Hex.HexConvertors.Extensions;
 using Scripts.EVM.Remote;
+using WalletConnectSharp.Sign.Models;
 
 namespace Scripts.EVM.Token
 {
@@ -135,7 +136,12 @@ namespace Scripts.EVM.Token
             const string method = EthMethod.SafeMint;
             var destination = await web3.Signer.GetAddress();
             var contract = web3.ContractBuilder.Build(abi, contractAddress);
-            return await contract.Send(method, new object[] { destination, uri });
+            var response =  await contract.Send(method, new object[]
+            {
+                destination,
+                uri
+            });
+            return response;
         }
 
         /// <summary>

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc20/Erc20Calls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc20/Erc20Calls.cs
@@ -99,7 +99,6 @@ public class Erc20Calls : MonoBehaviour
     /// </summary>
     public async void MintErc20()
     {
-        string toAccount = await Web3Accessor.Web3.Signer.GetAddress();
         var response = await Erc20.MintErc20(Web3Accessor.Web3, Contracts.Erc20, toAccount, amountMint);
         var output = SampleOutputUtil.BuildOutputValue(response);
         SampleOutputUtil.PrintResult(output, nameof(Erc20), nameof(Erc20.MintErc20));


### PR DESCRIPTION
Tx hash wasn't being populated correctly, altered all 3 sample mint functions, and they now return hashes, yay. Closes #819 

To Test:
Load up the sample scene and try mint for erc20/721/1155

Expected result:
Hashes!

![image](https://github.com/ChainSafe/web3.unity/assets/57473220/9c2a7686-c8c4-4f96-a569-cbb7e145bc3f)
