### PR TITLE
async ISigner.GetAddress() method -> sync ISigner.PublicAddress property

### DIFF
--- a/Packages/io.chainsafe.web3-unity.ramp/Runtime/Scripts/RampExchangerWebGL.cs
+++ b/Packages/io.chainsafe.web3-unity.ramp/Runtime/Scripts/RampExchangerWebGL.cs
@@ -49,7 +49,7 @@ namespace ChainSafe.Gaming.Exchangers.Ramp
 
         public async Task<OnRampPurchaseData> BuyCrypto(RampBuyWidgetSettings settings)
         {
-            var userAddress = settings.OverrideUserAddress ?? await signer.GetAddress();
+            var userAddress = settings.OverrideUserAddress ?? signer.PublicAddress;
             var hostLogoUrl = settings.OverrideHostLogoUrl ?? config.HostLogoUrl;
             var hostAppName = settings.OverrideHostAppName ?? config.HostAppName;
             var webhookStatusUrl = config.WebhookStatusUrl ?? settings.OverrideWebhookStatusUrl;
@@ -71,7 +71,7 @@ namespace ChainSafe.Gaming.Exchangers.Ramp
 
         public async Task<OffRampSaleData> SellCrypto(RampSellWidgetSettings settings)
         {
-            var userAddress = settings.OverrideUserAddress ?? await signer.GetAddress();
+            var userAddress = settings.OverrideUserAddress ?? signer.PublicAddress;
             var hostLogoUrl = settings.OverrideHostLogoUrl ?? config.HostLogoUrl;
             var hostAppName = settings.OverrideHostAppName ?? config.HostAppName;
             var offrampWebhookV3Url = config.OfframpWebHookV3Url ?? settings.OverrideOfframpWebHookV3Url;
@@ -93,7 +93,7 @@ namespace ChainSafe.Gaming.Exchangers.Ramp
 
         public async Task<RampTransactionData> BuyOrSellCrypto(RampBuyOrSellWidgetSettings settings)
         {
-            var userAddress = settings.OverrideUserAddress ?? await signer.GetAddress();
+            var userAddress = settings.OverrideUserAddress ?? signer.PublicAddress;
             var hostLogoUrl = settings.OverrideHostLogoUrl ?? config.HostLogoUrl;
             var hostAppName = settings.OverrideHostAppName ?? config.HostAppName;
             var webhookStatusUrl = config.WebhookStatusUrl ?? settings.OverrideWebhookStatusUrl;

--- a/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Web3AuthWallet.cs
+++ b/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Web3AuthWallet.cs
@@ -5,7 +5,6 @@ using ChainSafe.Gaming.Evm.Transactions;
 using ChainSafe.Gaming.InProcessSigner;
 using ChainSafe.Gaming.InProcessTransactionExecutor;
 using ChainSafe.Gaming.InProcessTransactionExecutor.Unity;
-using ChainSafe.Gaming.Web3;
 using ChainSafe.Gaming.Web3.Analytics;
 using ChainSafe.Gaming.Web3.Core;
 using ChainSafe.Gaming.Web3.Core.Evm;
@@ -40,6 +39,11 @@ namespace ChainSafe.GamingSdk.Web3Auth
             this.rpcProvider = rpcProvider;
             this.analyticsClient = analyticsClient;
         }
+
+        /// <summary>
+        /// Gets the blockchain address associated with this wallet.
+        /// </summary>
+        public string PublicAddress => signer.PublicAddress;
 
         /// <summary>
         /// Asynchronously prepares the Web3Auth wallet for operation, triggered when initializing the module in the dependency injection work flow.
@@ -97,12 +101,6 @@ namespace ChainSafe.GamingSdk.Web3Auth
                 logoutTcs.SetResult(null);
             }
         }
-
-        /// <summary>
-        /// Gets the blockchain address associated with this wallet.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous operation and returns the blockchain address as a string.</returns>
-        public Task<string> GetAddress() => signer.GetAddress();
 
         /// <summary>
         /// Signs a message using the private key associated with this wallet.

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Remote/CSServer.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Remote/CSServer.cs
@@ -3,10 +3,8 @@ using System.Text;
 using System.Threading.Tasks;
 using ChainSafe.Gaming.UnityPackage.Model;
 using ChainSafe.Gaming.Web3;
-using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Networking;
-using Scripts.EVM.Token;
 
 namespace Scripts.EVM.Remote
 {

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc1155.cs
@@ -107,7 +107,7 @@ namespace Scripts.EVM.Token
         {
             byte[] dataObject = { };
             const string method = EthMethod.Mint;
-            var destination = await web3.Signer.GetAddress();
+            var destination = web3.Signer.PublicAddress;
             var contract = web3.ContractBuilder.Build(abi, contractAddress);
             var response = await contract.Send(method, new object[]
             {
@@ -130,7 +130,7 @@ namespace Scripts.EVM.Token
         /// <returns></returns>
         public static async Task<object[]> TransferErc1155(Web3 web3, string contractAddress, BigInteger tokenId, BigInteger amount, string toAccount)
         {
-            var account = await web3.Signer.GetAddress();
+            var account = web3.Signer.PublicAddress;
             var abi = ABI.Erc1155;
             var method = EthMethod.SafeTransferFrom;
             byte[] dataObject = { };

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc20.cs
@@ -34,7 +34,7 @@ namespace Scripts.EVM.Token
         public static async Task<BigInteger> CustomTokenBalance(Web3 web3, string contractAbi, string contractAddress)
         {
             var contract = web3.ContractBuilder.Build(contractAbi, contractAddress);
-            string address = await web3.Signer.GetAddress();
+            string address = web3.Signer.PublicAddress;
             var contractData = await contract.Call(EthMethod.BalanceOf, new object[] { address });
             return BigInteger.Parse(contractData[0].ToString());
         }

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc721.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Erc721.cs
@@ -132,7 +132,7 @@ namespace Scripts.EVM.Token
         public static async Task<object[]> MintErc721(Web3 web3, string abi, string contractAddress, string uri)
         {
             const string method = EthMethod.SafeMint;
-            var destination = await web3.Signer.GetAddress();
+            var destination = web3.Signer.PublicAddress;
             var contract = web3.ContractBuilder.Build(abi, contractAddress);
             var response = await contract.Send(method, new object[]
             {
@@ -154,7 +154,7 @@ namespace Scripts.EVM.Token
         {
             var abi = ABI.Erc721;
             var method = EthMethod.SafeTransferFrom;
-            var account = await web3.Signer.GetAddress();
+            var account = web3.Signer.PublicAddress;
             var contract = web3.ContractBuilder.Build(abi, contractAddress);
 
             var response = await contract.Send(method, new object[]

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Evm.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Token/Evm.cs
@@ -60,7 +60,7 @@ namespace Scripts.EVM.Token
         {
             var transactionRequest = new TransactionRequest
             {
-                To = await web3.Signer.GetAddress(),
+                To = web3.Signer.PublicAddress,
                 Value = new HexBigInteger(100000)
             };
             var transactionResponse = await web3.TransactionExecutor.SendTransaction(transactionRequest);
@@ -71,7 +71,7 @@ namespace Scripts.EVM.Token
         {
             var transactionRequest = new TransactionRequest
             {
-                To = await web3.Signer.GetAddress(),
+                To = web3.Signer.PublicAddress,
                 Value = new HexBigInteger(10000000)
             };
             var transactionResponse = await web3.TransactionExecutor.SendTransaction(transactionRequest);
@@ -82,7 +82,7 @@ namespace Scripts.EVM.Token
 
         public static async Task<BigInteger> UseRegisteredContract(Web3 web3, string contractName, string method)
         {
-            var account = await web3.Signer.GetAddress();
+            var account = web3.Signer.PublicAddress;
             var contract = web3.ContractBuilder.Build(contractName);
             var response = await contract.Call(method, new[] { account });
             var balance = BigInteger.Parse(response[0].ToString());
@@ -125,7 +125,7 @@ namespace Scripts.EVM.Token
         // todo extract in a separate service
         public static async Task<bool> SignVerify(Web3 web3, string message)
         {
-            var playerAccount = await web3.Signer.GetAddress();
+            var playerAccount = web3.Signer.PublicAddress;
             var signatureString = await web3.Signer.SignMessage(message);
             var msg = "\x19" + "Ethereum Signed Message:\n" + message.Length + message;
             var msgHash = new Sha3Keccack().CalculateHash(Encoding.UTF8.GetBytes(msg));

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/Samples/GelatoSample.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/Samples/GelatoSample.cs
@@ -171,7 +171,7 @@ public class GelatoSample
         {
             Target = target,
             Data = data,
-            User = await _web3.Signer.GetAddress(),
+            User = _web3.Signer.PublicAddress,
         });
 
         while (true)

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/WebGLWallet.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/WebGLWallet/WebGLWallet.cs
@@ -20,30 +20,26 @@ namespace ChainSafe.Gaming.Wallets
     public class WebGLWallet : ISigner, ITransactionExecutor, ILifecycleParticipant
     {
         private readonly IRpcProvider provider;
-        [CanBeNull] private string address;
 
         public WebGLWallet(IRpcProvider provider)
         {
             this.provider = provider;
         }
 
+        [CanBeNull]
+        public string PublicAddress { get; private set; }
+
         public async ValueTask WillStartAsync()
         {
             // Get user address
             JS_resetConnectAccount();
             JS_web3Connect();
-            address = await PollJsSide(JS_getConnectAccount);
+            PublicAddress = await PollJsSide(JS_getConnectAccount);
         }
 
         public ValueTask WillStopAsync()
         {
             return new ValueTask(Task.CompletedTask);
-        }
-
-        public Task<string> GetAddress()
-        {
-            address.AssertNotNull(nameof(address));
-            return Task.FromResult(address);
         }
 
         public async Task<string> SignMessage(string message)
@@ -189,6 +185,8 @@ namespace ChainSafe.Gaming.Wallets
     // Stub implementation for other platforms
     public class WebGLWallet : ISigner, ITransactionExecutor, ILifecycleParticipant
     {
+        public string PublicAddress => throw new NotImplementedException();
+        
         public ValueTask WillStartAsync()
         {
             throw new Web3Exception(
@@ -196,11 +194,6 @@ namespace ChainSafe.Gaming.Wallets
         }
 
         public ValueTask WillStopAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<string> GetAddress()
         {
             throw new NotImplementedException();
         }

--- a/Packages/io.chainsafe.web3-unity/Tests/Runtime/EvmTests.cs
+++ b/Packages/io.chainsafe.web3-unity/Tests/Runtime/EvmTests.cs
@@ -48,7 +48,7 @@ public class EvmTests : SampleTestsBase
     [UnityTest]
     public IEnumerator TestContractCall()
     {
-        var address = web3.Signer.GetAddress().Result;
+        var address = web3.Signer.PublicAddress;
         object[] args = { address };
         var callContract = Evm.ContractCall(web3, ContractCallMethod, ABI.ArrayTotal, Contracts.ArrayTotal, args);
         yield return new WaitUntil(() => callContract.IsCompleted);

--- a/src/ChainSafe.Gaming.Gelato/Gelato.cs
+++ b/src/ChainSafe.Gaming.Gelato/Gelato.cs
@@ -102,7 +102,7 @@ namespace ChainSafe.GamingSdk.Gelato
                     ChainId = int.Parse(chainConfig.ChainId),
                     Target = request.Target,
                     Data = request.Data,
-                    User = await signer.GetAddress(),
+                    User = signer.PublicAddress,
                     UserDeadline = request.UserDeadline,
                     UserNonce = request.UserNonce,
                     FeeToken = request.FeeToken,

--- a/src/ChainSafe.Gaming.InProcessSigner/InProcessSigner.cs
+++ b/src/ChainSafe.Gaming.InProcessSigner/InProcessSigner.cs
@@ -15,8 +15,8 @@ namespace ChainSafe.Gaming.InProcessSigner
     /// </summary>
     public class InProcessSigner : ISigner
     {
-        private EthECKey privateKey;
-        private EthereumMessageSigner messageSigner;
+        private readonly EthECKey privateKey;
+        private readonly EthereumMessageSigner messageSigner;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InProcessSigner"/> class.
@@ -33,8 +33,8 @@ namespace ChainSafe.Gaming.InProcessSigner
         /// <summary>
         /// Implementation of <see cref="ISigner.GetAddress"/> using In Process.
         /// </summary>
-        /// <returns>Public address of signer.</returns>
-        public Task<string> GetAddress() => Task.FromResult(privateKey.GetPublicAddress());
+        /// <value>Public address of signer.</value>
+        public string PublicAddress => privateKey.GetPublicAddress();
 
         /// <summary>
         /// Implementation of <see cref="ISigner.SignMessage"/> using In Process.

--- a/src/ChainSafe.Gaming.Lootboxes.Chainlink/LootboxService.cs
+++ b/src/ChainSafe.Gaming.Lootboxes.Chainlink/LootboxService.cs
@@ -126,7 +126,7 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
 
         public async Task<uint> BalanceOf(uint lootboxType)
         {
-            var playerAddress = await this.GetCurrentPlayerAddress();
+            var playerAddress = this.GetCurrentPlayerAddress();
 
             return await this.BalanceOf(playerAddress, lootboxType);
         }
@@ -165,7 +165,7 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
 
         public async Task<bool> IsOpeningLootbox()
         {
-            var playerAddress = await this.GetCurrentPlayerAddress();
+            var playerAddress = this.GetCurrentPlayerAddress();
             var response = await this.contract.Call("openerRequests", new object[] { playerAddress });
             var requests = (BigInteger)response[0];
             return requests > 0;
@@ -173,7 +173,7 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
 
         public async Task<uint> OpeningLootboxType()
         {
-            var playerAddress = await this.GetCurrentPlayerAddress();
+            var playerAddress = this.GetCurrentPlayerAddress();
 
             // This response is actually very different from all the others since it returns several components
             var response = (List<ParameterOutput>)(await this.contract.Call("getOpenerRequestDetails", new object[] { playerAddress }))[0];
@@ -210,7 +210,7 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
 
         public async Task<bool> CanClaimRewards()
         {
-            var playerAddress = await this.GetCurrentPlayerAddress();
+            var playerAddress = this.GetCurrentPlayerAddress();
 
             return await this.CanClaimRewards(playerAddress);
         }
@@ -227,7 +227,7 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
 
         public async Task<LootboxRewards> ClaimRewards()
         {
-            var playerAddress = await this.GetCurrentPlayerAddress();
+            var playerAddress = this.GetCurrentPlayerAddress();
 
             return await this.ClaimRewards(playerAddress);
         }
@@ -298,14 +298,14 @@ namespace ChainSafe.Gaming.Lootboxes.Chainlink
             }
         }
 
-        private async Task<string> GetCurrentPlayerAddress()
+        private string GetCurrentPlayerAddress()
         {
             if (this.signer is null)
             {
                 throw new Web3Exception($"No {nameof(ISigner)} was registered. Can't get current user's address.");
             }
 
-            return await this.signer.GetAddress();
+            return signer.PublicAddress;
         }
     }
 }

--- a/src/ChainSafe.Gaming.MetaMask/MetaMaskTransactionExecutor.cs
+++ b/src/ChainSafe.Gaming.MetaMask/MetaMaskTransactionExecutor.cs
@@ -47,7 +47,7 @@ namespace ChainSafe.Gaming.MetaMask
         {
             if (string.IsNullOrEmpty(transaction.From))
             {
-                transaction.From = await signer.GetAddress();
+                transaction.From = signer.PublicAddress;
             }
 
             TransactionInput transactionInput = new TransactionInput

--- a/src/ChainSafe.Gaming.Tests/ChainsafeRPCTests.cs
+++ b/src/ChainSafe.Gaming.Tests/ChainsafeRPCTests.cs
@@ -47,13 +47,8 @@ namespace ChainSafe.Gaming.Tests
             var secondAccountTask = Web3Util.CreateWeb3(1).AsTask();
             secondAccountTask.Wait();
 
-            var firstWalletAddressTask = firstAccount.Signer.GetAddress();
-            firstWalletAddressTask.Wait();
-
-            firstWalletAddress = firstWalletAddressTask.Result;
-            var secondaryWalletAddressTask = secondAccountTask.Result.Signer.GetAddress();
-            secondaryWalletAddressTask.Wait();
-            secondaryWalletAddress = secondaryWalletAddressTask.Result;
+            firstWalletAddress = firstAccount.Signer.PublicAddress;
+            secondaryWalletAddress = secondAccountTask.Result.Signer.PublicAddress;
 
             var amount = new HexBigInteger(1000000);
             var txTask = firstAccount.TransactionExecutor.SendTransaction(new TransactionRequest
@@ -234,7 +229,7 @@ namespace ChainSafe.Gaming.Tests
         [Test]
         public void CallContractMethodTest()
         {
-            var address = firstAccount.Signer.GetAddress().Result;
+            var address = firstAccount.Signer.PublicAddress;
             var contract = firstAccount.ContractBuilder.Build(nft721ABI, nft721Address);
 
             var ret = contract.Send("safeMint", new object[] { address }).Result;

--- a/src/ChainSafe.Gaming.Tests/ProvidersSendTests.cs
+++ b/src/ChainSafe.Gaming.Tests/ProvidersSendTests.cs
@@ -57,10 +57,10 @@ namespace ChainSafe.Gaming.Tests
         public void SendTransactionTest()
         {
             // Get initial balances and addresses for both sender and receiver accounts.
-            var fromAddress = firstAccount.Signer.GetAddress().Result;
+            var fromAddress = firstAccount.Signer.PublicAddress;
             var fromInitialBalance = firstAccount.RpcProvider.GetBalance(fromAddress).Result.Value;
 
-            var toAddress = secondAccount.Signer.GetAddress().Result;
+            var toAddress = secondAccount.Signer.PublicAddress;
             var toInitialBalance = firstAccount.RpcProvider.GetBalance(toAddress).Result.Value;
 
             var amount = new HexBigInteger(1000000);

--- a/src/ChainSafe.Gaming.WalletConnect/WalletConnectSigner.cs
+++ b/src/ChainSafe.Gaming.WalletConnect/WalletConnectSigner.cs
@@ -16,27 +16,25 @@ namespace ChainSafe.Gaming.WalletConnect
     {
         private readonly IWalletConnectProvider provider;
 
-        private string address;
-
         public WalletConnectSigner(IWalletConnectProvider provider)
         {
             this.provider = provider;
         }
 
+        public string PublicAddress { get; private set; }
+
         public async ValueTask WillStartAsync()
         {
-            address = await provider.Connect();
+            PublicAddress = await provider.Connect();
         }
 
         ValueTask ILifecycleParticipant.WillStopAsync() => new(Task.CompletedTask);
 
         public Task OnLogout() => provider.Disconnect();
 
-        public Task<string> GetAddress() => Task.FromResult(address);
-
         public async Task<string> SignMessage(string message)
         {
-            var requestData = new EthSignMessage(message, address);
+            var requestData = new EthSignMessage(message, PublicAddress);
             var hash = await provider.Request(requestData);
 
             if (!ValidateSignResponse(hash))
@@ -50,7 +48,7 @@ namespace ChainSafe.Gaming.WalletConnect
 
         public async Task<string> SignTypedData<TStructType>(SerializableDomain domain, TStructType message)
         {
-            var requestData = new EthSignTypedData<TStructType>(address, domain, message);
+            var requestData = new EthSignTypedData<TStructType>(PublicAddress, domain, message);
             var hash = await provider.Request(requestData);
 
             if (!ValidateSignResponse(hash))

--- a/src/ChainSafe.Gaming.WalletConnect/WalletConnectTransactionExecutor.cs
+++ b/src/ChainSafe.Gaming.WalletConnect/WalletConnectTransactionExecutor.cs
@@ -32,7 +32,7 @@ namespace ChainSafe.Gaming.WalletConnect
         {
             if (string.IsNullOrEmpty(transaction.From))
             {
-                transaction.From = await signer.GetAddress();
+                transaction.From = signer.PublicAddress;
             }
 
             var requestData = new EthSendTransaction(new TransactionModel

--- a/src/ChainSafe.Gaming/RPC/Contracts/Contract.cs
+++ b/src/ChainSafe.Gaming/RPC/Contracts/Contract.cs
@@ -261,7 +261,7 @@ namespace ChainSafe.Gaming.Evm.Contracts
             var function = contractBuilder.GetFunctionBuilder(method);
             var txReq = overwrite ?? new TransactionRequest();
 
-            txReq.From ??= signer == null ? null : await signer.GetAddress();
+            txReq.From ??= signer?.PublicAddress;
             txReq.To ??= address;
             txReq.Data ??= function.GetData(parameters);
             try

--- a/src/ChainSafe.Gaming/Web3/Core/Evm/ISigner.cs
+++ b/src/ChainSafe.Gaming/Web3/Core/Evm/ISigner.cs
@@ -16,11 +16,11 @@ namespace ChainSafe.Gaming.Evm.Signers
         /// <summary>
         /// Asynchronously retrieves the wallet address associated with the signer.
         /// </summary>
-        /// <returns>
-        /// A <see cref="Task"/> representing the asynchronous operation. The task result contains
-        /// the wallet address associated with the signer as a string.
-        /// </returns>
-        Task<string> GetAddress();
+        /// <value>
+        ///     A <see cref="Task"/> representing the asynchronous operation. The task result contains
+        ///     the wallet address associated with the signer as a string.
+        /// </value>
+        string PublicAddress { get; }
 
         /// <summary>
         /// Asynchronously signs a given message.

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/CreateApproval.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/CreateApproval.cs
@@ -13,7 +13,7 @@ public class CreateApproval : MonoBehaviour
     public async void ApproveTransaction()
     {
         var chainConfig = Web3Accessor.Web3.ChainConfig;
-        var response = await CSServer.CreateApproveTransaction(Web3Accessor.Web3, chainConfig.Chain, chainConfig.Network, await Web3Accessor.Web3.Signer.GetAddress(), tokenType);
+        var response = await CSServer.CreateApproveTransaction(Web3Accessor.Web3, chainConfig.Chain, chainConfig.Network, Web3Accessor.Web3.Signer.PublicAddress, tokenType);
         Debug.Log("Response: " + response.connection.chain);
 
         try

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/GetListedCollections.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/GetListedCollections.cs
@@ -36,7 +36,7 @@ public class GetListedCollections : MonoBehaviour
     }
     async void LoadNftDataBuyPage()
     {
-        account = await Web3Accessor.Web3.Signer.GetAddress();
+        account = Web3Accessor.Web3.Signer.PublicAddress;
         var chainConfig = Web3Accessor.Web3.ChainConfig;
         // create a reference to a list and iterate through it to gain token id
         List<string> tokenIdList = new();

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/GetListedNFT.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/GetListedNFT.cs
@@ -128,7 +128,7 @@ public class GetListedNFT : MonoBehaviour
     {
         var chainConfig = Web3Accessor.Web3.ChainConfig;
         BuyNFT.Response response = await CSServer.CreatePurchaseNftTransaction(Web3Accessor.Web3, chainConfig.Chain, chainConfig.Network,
-            await Web3Accessor.Web3.Signer.GetAddress(), _itemID, _itemPrice, _tokenType);
+            Web3Accessor.Web3.Signer.PublicAddress, _itemID, _itemPrice, _tokenType);
         Debug.Log("Account: " + response.tx.account);
         Debug.Log("To : " + response.tx.to);
         Debug.Log("Value : " + response.tx.value);

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/ListCollections.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/ListCollections.cs
@@ -39,7 +39,7 @@ public class ListCollections : MonoBehaviour
     async void LoadNftDataSellPage()
     {
         var chainConfig = Web3Accessor.Web3.ChainConfig;
-        account = await Web3Accessor.Web3.Signer.GetAddress();
+        account = Web3Accessor.Web3.Signer.PublicAddress;
         // create a reference to a list and iterate through it to gain token id
         List<string> tokenIdList = new List<String>();
         // checks if filter should be applied

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/ListNft.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Prefabs/Minter/ListNft.cs
@@ -30,13 +30,13 @@ namespace Web3Unity.Scripts.Prefabs.Minter
         public Text noListedItems;
         public Text playerAccount;
 
-        public async void Awake()
+        public void Awake()
         {
             description.text = "";
             tokenURI.text = "";
             isApproved.text = "";
             contractAddr.text = "";
-            account = await Web3Accessor.Web3.Signer.GetAddress();
+            account = Web3Accessor.Web3.Signer.PublicAddress;
         }
 
         // Start is called before the first frame update

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/AccountLabel.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/AccountLabel.cs
@@ -7,9 +7,9 @@ public class AccountLabel : MonoBehaviour
 {
     private TMP_Text label;
 
-    private async void Awake()
+    private void Awake()
     {
         label = GetComponent<TMP_Text>();
-        label.text = await Web3Accessor.Web3.Signer.GetAddress();
+        label.text = Web3Accessor.Web3.Signer.PublicAddress;
     }
 }

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/EVM/EvmCalls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/EVM/EvmCalls.cs
@@ -118,7 +118,7 @@ public class EvmCalls : MonoBehaviour
     {
         object[] args =
         {
-            await Web3Accessor.Web3.Signer.GetAddress()
+            Web3Accessor.Web3.Signer.PublicAddress
         };
         var response = await Evm.ContractCall(Web3Accessor.Web3, methodCall, ABI.ArrayTotal, Contracts.ArrayTotal, args);
         Debug.Log(response);


### PR DESCRIPTION
Refactored ISigner's async `GetAddress()` method into a sync `PublicAddress` property as none of the implementations required async.