### PR TITLE
Easy sample calls

### DIFF
--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/EVM/EvmCalls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/EVM/EvmCalls.cs
@@ -19,35 +19,29 @@ using TransactionReceipt = ChainSafe.Gaming.Evm.Transactions.TransactionReceipt;
 public class EvmCalls : MonoBehaviour
 {
     #region Fields
-
-    #region IPFS
-
-    private string apiKey = "YOUR_CHAINSAFE_STORE_API_KEY";
-    private string data = "YOUR_DATA";
-    private string bucketId = "BUCKET_ID";
-    private string path = "/PATH";
-    private string filename = "FILENAME.EXT";
-
-    #endregion
+    [Header("Change the fields below for testing purposes")]
 
     #region Contract Send
-
-    private string methodSend = "addTotal";
-    private int increaseAmountSend = 1;
+    
+    [Header("Contract Send")]
+    [SerializeField] private string methodSend = "addTotal";
+    [SerializeField] private int increaseAmountSend = 1;
 
     #endregion
 
     #region Contract Call
-
-    private string methodCall = "myTotal";
+    
+    [Header("Contract Call")]
+    [SerializeField] private string methodCall = "myTotal";
 
     #endregion
 
     #region Get Send Array
-
-    private string methodArrayGet = "getStore";
-    private string methodArraySend = "setStore";
-    private string[] stringArraySend =
+    
+    [Header("Array Calls")]
+    [SerializeField] private string methodArrayGet = "getStore";
+    [SerializeField] private string methodArraySend = "setStore";
+    [SerializeField] private string[] stringArraySend =
     {
         "0xFb3aECf08940785D4fB3Ad87cDC6e1Ceb20e9aac",
         "0x92d4040e4f3591e60644aaa483821d1bd87001e3"
@@ -56,37 +50,53 @@ public class EvmCalls : MonoBehaviour
     #endregion
 
     #region Sign Verify Sha3
-
-    private string messageSign = "The right man in the wrong place can make all the difference in the world.";
-    private string messageSignVerify = "A man chooses, a slave obeys.";
-    private string messageSha = "It’s dangerous to go alone, take this!";
+    
+    [Header("Sign Verify SHA3 calls")]
+    [SerializeField] private string messageSign = "The right man in the wrong place can make all the difference in the world.";
+    [SerializeField] private string messageSignVerify = "A man chooses, a slave obeys.";
+    [SerializeField] private string messageSha = "It’s dangerous to go alone, take this!";
 
     #endregion
 
     #region Send Transaction
-
-    private string toAddress = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
+    
+    [Header("Send Transaction Call")]
+    [SerializeField] private string toAddress = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
 
     #endregion
 
     #region Registered Contract
-
-    private string registeredContractName = "CsTestErc20";
+    
+    [Header("Registered Contract Call")]
+    [SerializeField] private string registeredContractName = "CsTestErc20";
 
     #endregion
 
     #region ECDSA
-
-    private string ecdsaKey = "0x78dae1a22c7507a4ed30c06172e7614eb168d3546c13856340771e63ad3c0081";
-    private string ecdsaMessage = "This is a test message";
-    private string transactionHash = "0x123456789";
-    private string chainId = "11155111";
+    
+    [Header("ECDSA Calls")]
+    [SerializeField] private string ecdsaKey = "0x78dae1a22c7507a4ed30c06172e7614eb168d3546c13856340771e63ad3c0081";
+    [SerializeField] private string ecdsaMessage = "This is a test message";
+    [SerializeField] private string transactionHash = "0x123456789";
+    [SerializeField] private string chainId = "11155111";
 
     #endregion
 
     #region Multi Call
+    
+    [Header("MutliCall")]
+    [SerializeField] private string Erc20Account = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
 
-    private string Erc20Account = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
+    #endregion
+    
+    #region IPFS
+    
+    [Header("IPFS VALUES")]
+    [SerializeField] private string apiKey = "YOUR_CHAINSAFE_STORE_API_KEY";
+    [SerializeField] private string data = "YOUR_DATA";
+    [SerializeField] private string bucketId = "BUCKET_ID";
+    [SerializeField] private string path = "/PATH";
+    [SerializeField] private string filename = "FILENAME.EXT";
 
     #endregion
 

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc1155/Erc1155Calls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc1155/Erc1155Calls.cs
@@ -13,45 +13,52 @@ using UnityEngine.UI;
 public class Erc1155Calls : MonoBehaviour
 {
     #region Fields
+    [Header("Change the fields below for testing purposes")]
 
     #region Balance Of
-
-    private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
-    private string tokenIdBalanceOf = "1";
+    
+    [Header("Balance Of Call")]
+    [SerializeField] private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
+    [SerializeField] private string tokenIdBalanceOf = "1";
 
     #endregion
 
     #region Balance Of Batch
-
-    private string[] accountsBalanceOfBatch = { "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2", "0xE51995Cdb3b1c109E0e6E67ab5aB31CDdBB83E4a" };
-    private string[] tokenIdsBalanceOfBatch = { "1", "2" };
+    
+    [Header("Balance Of Batch Call")]
+    [SerializeField] private string[] accountsBalanceOfBatch = { "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2", "0xE51995Cdb3b1c109E0e6E67ab5aB31CDdBB83E4a" };
+    [SerializeField] private string[] tokenIdsBalanceOfBatch = { "1", "2" };
 
     #endregion
 
     #region Uri
-
-    private string tokenIdUri = "1";
+    
+    [Header("URI Call")]
+    [SerializeField] private string tokenIdUri = "1";
 
     #endregion
 
     #region Mint
-
-    private BigInteger idMint = 1;
-    private BigInteger amountMint = 1;
+    
+    [Header("Mint Call")]
+    [SerializeField] private BigInteger idMint = 1;
+    [SerializeField] private BigInteger amountMint = 1;
 
     #endregion
 
     #region Transfer
-
-    private string toAccountTransfer = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
-    private BigInteger tokenIdTransfer = 1;
-    private BigInteger amountTransfer = 1;
+    
+    [Header("Transfer Call")]
+    [SerializeField] private string toAccountTransfer = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
+    [SerializeField] private BigInteger tokenIdTransfer = 1;
+    [SerializeField] private BigInteger amountTransfer = 1;
 
     #endregion
 
     #region Texture
-
-    private string tokenIdTexture = "0";
+    
+    [Header("Token ID for IPFS texture")]
+    [SerializeField] private string tokenIdTexture = "0";
     public RawImage rawImage;
 
     #endregion

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc20/Erc20Calls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc20/Erc20Calls.cs
@@ -9,23 +9,27 @@ using UnityEngine;
 public class Erc20Calls : MonoBehaviour
 {
     #region Fields
+    [Header("Change the fields below for testing purposes")]
 
     #region Balance Of
-
-    private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
+    
+    [Header("Balance Of Call")]
+    [SerializeField] private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
 
     #endregion
 
     #region Mint
-
-    private BigInteger amountMint = 1000000000000000000;
+    
+    [Header("Mint Call")]
+    [SerializeField] private BigInteger amountMint = 1000000000000000000;
 
     #endregion
 
     #region Transfer
-
-    private const string toAccount = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
-    private BigInteger amountTransfer = 1000000000000000;
+    
+    [Header("Transfer Call")]
+    [SerializeField] private string toAccount = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
+    [SerializeField] private BigInteger amountTransfer = 1000000000000000;
 
     #endregion
 

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc721/Erc721Calls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Erc721/Erc721Calls.cs
@@ -13,42 +13,49 @@ using UnityEngine;
 public class Erc721Calls : MonoBehaviour
 {
     #region Fields
+    [Header("Change the fields below for testing purposes")]
 
     #region Balance Of
-
-    private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
+    
+    [Header("Balance Of Call")]
+    [SerializeField] private string accountBalanceOf = "0xd25b827D92b0fd656A1c829933e9b0b836d5C3e2";
 
     #endregion
 
     #region Owner Of
-
-    private string tokenIdOwnerOf = "1";
+    
+    [Header("Owner Of Call")]
+    [SerializeField] private string tokenIdOwnerOf = "1";
 
     #endregion
-
+    
+    [Header("Balance Of Batch Call")]
     #region Owner Of Batch
 
-    private string[] tokenIdsOwnerOfBatch = { "4", "50", "6" };
+    [SerializeField] private string[] tokenIdsOwnerOfBatch = { "4", "50", "6" };
 
     #endregion
 
     #region Uri
-
-    private string tokenIdUri = "0x01559ae4021a565d5cc4740f1cefa95de8c1fb193949ecd32c337b03047da501";
+    
+    [Header("URI Call")]
+    [SerializeField] private string tokenIdUri = "0x01559ae4021a565d5cc4740f1cefa95de8c1fb193949ecd32c337b03047da501";
 
     #endregion
 
     #region Mint
-
-    private string uriMint = "1";
+    
+    [Header("Mint Call")]
+    [SerializeField] private string uriMint = "1";
 
     #endregion
 
     #region Transfer
-
-    private string contractTransfer = "0x358AA13c52544ECCEF6B0ADD0f801012ADAD5eE3";
-    private string toAccountTransfer = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
-    private int tokenIdTransfer = 0;
+    
+    [Header("Transfer Call")]
+    [SerializeField] private string contractTransfer = "0x358AA13c52544ECCEF6B0ADD0f801012ADAD5eE3";
+    [SerializeField] private string toAccountTransfer = "0xdD4c825203f97984e7867F11eeCc813A036089D1";
+    [SerializeField] private int tokenIdTransfer = 0;
 
     #endregion
 

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Marketplace/MarketplaceCalls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.5.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Marketplace/MarketplaceCalls.cs
@@ -9,12 +9,17 @@ using UnityEngine;
 public class MarketplaceCalls : MonoBehaviour
 {
     #region fields
-
+    [Header("Change the fields below for testing purposes")]
+    
     #region Collections
     
+    [Header("721 Collection Call")]
     [SerializeField] private string collectionId721 = "d588268b-8a5b-486a-8ea1-4122b510d71e";
+    [Header("1155 Collection Call")]
     [SerializeField] private string collectionId1155 = "ebeaaee5-f7c2-4561-abb9-60ba749db7cd";
+    [Header("Marketplace Calls")]
     [SerializeField] private string marketplaceId = "4986983b-2bcc-4bb3-b0db-a3448fbdee2b";
+    [Header("Token Calls")]
     [SerializeField] private string tokenId = "0";
 
     #endregion


### PR DESCRIPTION
Sample fields serialized & descriptive headers added. Users can now edit the sample script objects in the hierarchy on the left in the sample scene to alter contract values as needed.

There are no functional changes with this PR so testing isn't required.

Closes #879 

![image](https://github.com/ChainSafe/web3.unity/assets/57473220/d6a3a0d1-6aa7-49bb-a244-e7a9097f5d41)
