### PR TITLE
Marketpalce prefab minor fixes

### DIFF
--- a/Packages/io.chainsafe.web3-unity.marketplace/Runtime/Scripts/Marketplace/Marketplace.cs
+++ b/Packages/io.chainsafe.web3-unity.marketplace/Runtime/Scripts/Marketplace/Marketplace.cs
@@ -167,7 +167,6 @@ namespace Scripts.EVM.Marketplace
             var formData = new List<IMultipartFormSection>
                 {
                     new MultipartFormDataSection("name", _name),
-                    new MultipartFormDataSection("description", _description),
                     new MultipartFormDataSection("owner", Web3Accessor.Web3.Signer.PublicAddress),
                     new MultipartFormDataSection("chain_id", Web3Accessor.Web3.ChainConfig.ChainId),
                     new MultipartFormDataSection("projectID", Web3Accessor.Web3.ProjectConfig.ProjectId),
@@ -175,8 +174,12 @@ namespace Scripts.EVM.Marketplace
                     new MultipartFormFileSection("banner", bannerImageData, "banner.png", "image/png"),
                     new MultipartFormDataSection("isImported", "true"),
                     new MultipartFormDataSection("contractAddress", ChainSafeContracts.MarketplaceContracts[Web3Accessor.Web3.ChainConfig.ChainId]),
-                    new MultipartFormDataSection("type", "erc721")
+                    new MultipartFormDataSection("type", "ERC721")
                 };
+            if (!string.IsNullOrEmpty(_description))
+            {
+                formData.Insert(1, new MultipartFormDataSection("description", _description));
+            }
             var path = "/collections";
             var collectionResponse = await CSServer.CreateData(_bearerToken, path, formData);
             var collectionData = JsonConvert.DeserializeObject<CollectionResponses.Collections>(collectionResponse);
@@ -213,7 +216,6 @@ namespace Scripts.EVM.Marketplace
                 var formData = new List<IMultipartFormSection>
                 {
                     new MultipartFormDataSection("name", _name),
-                    new MultipartFormDataSection("description", _description),
                     new MultipartFormDataSection("owner", Web3Accessor.Web3.Signer.PublicAddress),
                     new MultipartFormDataSection("chain_id", Web3Accessor.Web3.ChainConfig.ChainId),
                     new MultipartFormDataSection("projectID", Web3Accessor.Web3.ProjectConfig.ProjectId),
@@ -221,8 +223,12 @@ namespace Scripts.EVM.Marketplace
                     new MultipartFormFileSection("banner", bannerImageData, "banner.png", "image/png"),
                     new MultipartFormDataSection("isImported", "true"),
                     new MultipartFormDataSection("contractAddress", ChainSafeContracts.MarketplaceContracts[Web3Accessor.Web3.ChainConfig.ChainId]),
-                    new MultipartFormDataSection("type", "erc1155")
+                    new MultipartFormDataSection("type", "ERC1155")
                 };
+                if (!string.IsNullOrEmpty(_description))
+                {
+                    formData.Insert(1, new MultipartFormDataSection("description", _description));
+                }
                 var path = "/collections";
                 var collectionResponse = await CSServer.CreateData(_bearerToken, path, formData);
                 var collectionData = JsonConvert.DeserializeObject<CollectionResponses.Collections>(collectionResponse);
@@ -334,10 +340,13 @@ namespace Scripts.EVM.Marketplace
                 var formData = new List<IMultipartFormSection>
                 {
                     new MultipartFormDataSection("name", _name),
-                    new MultipartFormDataSection("description", _description),
                     new MultipartFormDataSection("chain_id", Web3Accessor.Web3.ChainConfig.ChainId),
                     new MultipartFormFileSection("banner", bannerImageData, "banner.png", "image/png")
                 };
+                if (!string.IsNullOrEmpty(_description))
+                {
+                    formData.Insert(1, new MultipartFormDataSection("description", _description));
+                }
                 var path = "/marketplaces";
                 var marketplaceResponse = await CSServer.CreateData(_bearerToken, path, formData);
                 Debug.Log(marketplaceResponse);

--- a/Packages/io.chainsafe.web3-unity.marketplace/Runtime/Scripts/Marketplace/Marketplace.cs
+++ b/Packages/io.chainsafe.web3-unity.marketplace/Runtime/Scripts/Marketplace/Marketplace.cs
@@ -6,6 +6,7 @@ using ChainSafe.Gaming.Evm.Transactions;
 using ChainSafe.Gaming.UnityPackage;
 using ChainSafe.Gaming.UnityPackage.Model;
 using ChainSafe.Gaming.Web3;
+using JetBrains.Annotations;
 using Nethereum.Hex.HexTypes;
 using Newtonsoft.Json;
 using Scripts.EVM.Remote;
@@ -257,15 +258,32 @@ namespace Scripts.EVM.Marketplace
         /// <param name="_collectionContract">721 collection contract to mint from/to</param>
         /// <param name="_uri">URI in full format i.e https://ipfs.chainsafe.io/ipfs/bafyjvzacdj4apx52hvbyjkwyf7i6a7t3pcqd4kw4xxfc67hgvn3a</param>
         /// <returns>Contract send data object</returns>
-        public static async Task<TransactionReceipt> Mint721CollectionNft(string _collectionContract, string _uri)
+        public static async Task<TransactionReceipt> Mint721CollectionNft(string _bearerToken, string _collectionContract, string _name, [CanBeNull] string _description)
         {
             try
             {
+                var imageData = await UploadPlatforms.GetImageData();
+                var formData = new List<IMultipartFormSection>
+                {
+                    new MultipartFormDataSection("name", _name),
+                    new MultipartFormFileSection("image", imageData, "nftImage.png", "image/png"),
+                    new MultipartFormDataSection("tokenType", "ERC721")
+                    // TODO add attributes to form later
+                    // attributes[0].trait_type: prop1
+                    // attributes[0].value: 100
+                };
+                if (!string.IsNullOrEmpty(_description))
+                {
+                    formData.Insert(2, new MultipartFormDataSection("description", _description));
+                }
+                var path = "/nft?hash=blake2b-208";
+                var collectionResponse = await CSServer.CreateData(_bearerToken, path, formData);
+                var collectionData = JsonConvert.DeserializeObject<ApiResponse>(collectionResponse);
                 var method = "mint";
                 object[] args =
                 {
                     Web3Accessor.Web3.Signer.PublicAddress,
-                    _uri
+                    collectionData.cid
                 };
                 var contract = Web3Accessor.Web3.ContractBuilder.Build(ABI.GeneralErc721, _collectionContract);
                 var data = await contract.SendWithReceipt(method, args);
@@ -285,16 +303,33 @@ namespace Scripts.EVM.Marketplace
         /// <param name="_uri">URI in full format i.e https://ipfs.chainsafe.io/ipfs/bafyjvzacdj4apx52hvbyjkwyf7i6a7t3pcqd4kw4xxfc67hgvn3a</param>
         /// <param name="_amount">Amount of Nfts to mint</param>
         /// <returns>Contract send data object</returns>
-        public static async Task<TransactionReceipt> Mint1155CollectionNft(string _collectionContract, string _uri, string _amount)
+        public static async Task<TransactionReceipt> Mint1155CollectionNft(string _bearerToken, string _collectionContract, string _amount, string _name, [CanBeNull] string _description)
         {
             try
             {
+                var imageData = await UploadPlatforms.GetImageData();
+                var formData = new List<IMultipartFormSection>
+                {
+                    new MultipartFormDataSection("name", _name),
+                    new MultipartFormFileSection("image", imageData, "nftImage.png", "image/png"),
+                    new MultipartFormDataSection("tokenType", "ERC1155")
+                    // TODO add attributes to form later
+                    // attributes[0].trait_type: prop1
+                    // attributes[0].value: 100
+                };
+                if (!string.IsNullOrEmpty(_description))
+                {
+                    formData.Insert(2, new MultipartFormDataSection("description", _description));
+                }
+                var path = "/nft?hash=blake2b-208";
+                var collectionResponse = await CSServer.CreateData(_bearerToken, path, formData);
+                var collectionData = JsonConvert.DeserializeObject<ApiResponse>(collectionResponse);
                 var method = "mint";
                 var amount = BigInteger.Parse(_amount);
                 object[] args =
                 {
                     Web3Accessor.Web3.Signer.PublicAddress,
-                    _uri,
+                    collectionData.cid,
                     amount
                 };
 
@@ -492,6 +527,14 @@ namespace Scripts.EVM.Marketplace
                 var value = property.GetValue(obj);
                 Debug.Log($"{property.Name}: {value}");
             }
+        }
+        
+        /// <summary>
+        /// Handles CID response from API for metadata uploads.
+        /// </summary>
+        public class ApiResponse
+        {
+            public string cid { get; set; }
         }
 
         #endregion

--- a/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Remote/CSServer.cs
+++ b/Packages/io.chainsafe.web3-unity/Runtime/Scripts/EVM/Remote/CSServer.cs
@@ -90,7 +90,12 @@ namespace Scripts.EVM.Remote
         public static async Task<string> CreateData(string _bearerToken, string _path,
             List<IMultipartFormSection> _formData)
         {
-            using (UnityWebRequest request = UnityWebRequest.Post($"{host}{Web3Accessor.Web3.ProjectConfig.ProjectId}{_path}", _formData))
+            var url = $"{host}{Web3Accessor.Web3.ProjectConfig.ProjectId}{_path}";
+            if (_path == "/nft?hash=blake2b-208")
+            {
+                url = "https://api.chainsafe.io/v1/nft?hash=blake2b-208";
+            }
+            using (UnityWebRequest request = UnityWebRequest.Post($"{url}", _formData))
             {
                 request.SetRequestHeader("Authorization", $"Bearer {_bearerToken}");
                 await request.SendWebRequest();

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Prefabs/GUI/MarketplaceGUI.prefab
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Prefabs/GUI/MarketplaceGUI.prefab
@@ -15504,7 +15504,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3594bd0b36708be40bfaecfe61e16ab7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  fillDuration: 2
   radialImage: {fileID: 5961661105869613969}
 --- !u!1 &7516127192911281330
 GameObject:

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseCollectionManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseCollectionManager.cs
@@ -1,18 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using ChainSafe.Gaming.Ipfs;
 using ChainSafe.Gaming.Marketplace;
 using ChainSafe.Gaming.Web3;
-using Newtonsoft.Json;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.UI;
 using EvmMarketplace = Scripts.EVM.Marketplace.Marketplace;
 using ChainSafe.Gaming.Marketplace.Models;
-using ChainSafe.Gaming.UnityPackage.Model;
 
 namespace ChainSafe.Gaming.Collection
 {
@@ -96,6 +92,11 @@ namespace ChainSafe.Gaming.Collection
         private async void PopulateCollectionItems(int index, string collectionType)
         {
             var projectResponse = await EvmMarketplace.GetProjectTokens();
+            if (index >= projectResponse.tokens.Count)
+            {
+                EventManagerMarketplace.RaiseToggleProcessingMenu();
+                return;
+            }
             var collectionContract = projectResponse.tokens[index].collection_id;
             if (!Enum.TryParse(collectionType, true, out CollectionType collectionTypeEnum))
             {

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseCollectionManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseCollectionManager.cs
@@ -98,6 +98,8 @@ namespace ChainSafe.Gaming.Collection
                 return;
             }
             var collectionContract = projectResponse.tokens[index].collection_id;
+            var mintCollectionNftConfigArgs = new EventManagerMarketplace.MintCollectionNftConfigEventArgs(null, collectionContract);
+            EventManagerMarketplace.RaiseMintCollectionNftManager(mintCollectionNftConfigArgs);
             if (!Enum.TryParse(collectionType, true, out CollectionType collectionTypeEnum))
             {
                 collectionTypeEnum = CollectionType.Unknown;

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseMarketplaceManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/BrowseMarketplaceManager.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 using System.Threading.Tasks;
-using ChainSafe.Gaming.Ipfs;
 using ChainSafe.Gaming.Web3;
 using TMPro;
 using UnityEngine;
@@ -12,8 +10,6 @@ using UnityEngine.UI;
 using EvmMarketplace = Scripts.EVM.Marketplace.Marketplace;
 using ChainSafe.Gaming.Marketplace.Models;
 using ChainSafe.Gaming.UnityPackage;
-using ChainSafe.Gaming.UnityPackage.Model;
-using Newtonsoft.Json;
 
 namespace ChainSafe.Gaming.Marketplace
 {
@@ -89,6 +85,11 @@ namespace ChainSafe.Gaming.Marketplace
         private async void PopulateMarketplaceItems(string marketplaceContract, int index)
         {
             var projectResponse = await EvmMarketplace.GetProjectItems();
+            if (index >= projectResponse.items.Count)
+            {
+                EventManagerMarketplace.RaiseToggleProcessingMenu();
+                return;
+            }
             var response = await EvmMarketplace.GetMarketplaceItems(projectResponse.items[index].marketplace_id);
             foreach (var item in response.items)
             {

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/CreateCollectionManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/CreateCollectionManager.cs
@@ -35,9 +35,6 @@ namespace ChainSafe.Gaming.Marketplace
         {
             if (processing) return;
             processing = true;
-            // form won't post with null values here, hacky and could be better.
-            nameInput.text ??= " ";
-            descriptionInput.text ??= " ";
             switch (typeDropDown.options[typeDropDown.value].text)
             {
                 case "721":

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/CreateMarketplaceManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/CreateMarketplaceManager.cs
@@ -1,4 +1,3 @@
-using System;
 using ChainSafe.Gaming.Web3;
 using TMPro;
 using UnityEngine;
@@ -35,9 +34,6 @@ namespace ChainSafe.Gaming.Marketplace
         {
             if (processing) return;
             processing = true;
-            // form won't post with null values here, hacky and could be better.
-            nameInput.text ??= " ";
-            descriptionInput.text ??= " ";
             CreateMarketplace(nameInput.text, descriptionInput.text, whiteListing);
         }
         

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/EventManagerMarketplace.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/EventManagerMarketplace.cs
@@ -18,6 +18,7 @@ namespace ChainSafe.Gaming.Marketplace
         public static event EventHandler<CollectionBrowserConfigEventArgs> ConfigureCollectionBrowserManager;
         public static event EventHandler<MarketplaceCreateConfigEventArgs> ConfigureMarketplaceCreateManager;
         public static event EventHandler<CollectionCreateConfigEventArgs> ConfigureCollectionCreateManager;
+        public static event EventHandler<MintCollectionNftConfigEventArgs> ConfigureMintCollectionNftManager;
         public static event EventHandler<ListNftToMarketplaceConfigEventArgs> ConfigureListNftToMarketplaceManager;
         public static event EventHandler<ListNftToMarketplaceTxEventArgs> ConfigureListNftToMarketplaceTxManager;
         public static event Action ToggleProcessingMenu;
@@ -37,6 +38,7 @@ namespace ChainSafe.Gaming.Marketplace
         public static event Action CloseSelectedCollection;
         public static event Action UploadMarketplaceImage;
         public static event Action ListNftToMarketplace;
+        public static event Action MintNftToCollection;
         public static event Action CreateMarketplace;
         public static event Action LogoutMarketplace;
         
@@ -85,9 +87,9 @@ namespace ChainSafe.Gaming.Marketplace
         }
         
         /// <summary>
-        /// Invokes ToggleMintNftToSelectionMenu.
+        /// Invokes ToggleMintNftToCollectionMenu.
         /// </summary>
-        public static void RaiseToggleMintNftToSelectionMenu()
+        public static void RaiseToggleMintNftToCollectionMenu()
         {
             ToggleMintNftToCollectionMenu?.Invoke();
         }
@@ -162,6 +164,11 @@ namespace ChainSafe.Gaming.Marketplace
         public static void RaiseCloseSelectedMarketplace()
         {
             CloseSelectedMarketplace?.Invoke();
+        }
+        
+        public static void RaiseMintNftToCollection()
+        {
+            MintNftToCollection?.Invoke();
         }
         
         /// <summary>
@@ -269,6 +276,15 @@ namespace ChainSafe.Gaming.Marketplace
             ConfigureCollectionCreateManager?.Invoke(null, args);
         }
         
+        /// <summary>
+        /// Configure marketplace create manager.
+        /// </summary>
+        /// <param name="args">Input args.</param>
+        public static void RaiseMintCollectionNftManager(MintCollectionNftConfigEventArgs args)
+        {
+            ConfigureMintCollectionNftManager?.Invoke(null, args);
+        }
+        
         #endregion
         
         /// <summary>
@@ -293,6 +309,9 @@ namespace ChainSafe.Gaming.Marketplace
             
             var listNftToMarketplaceCreateEventArgs = new ListNftToMarketplaceConfigEventArgs(string.Empty);
             RaiseConfigureListNftToMarketplaceManager(listNftToMarketplaceCreateEventArgs);
+            
+            var mintCollectionNftConfigEventArgs = new MintCollectionNftConfigEventArgs(string.Empty, string.Empty);
+            RaiseMintCollectionNftManager(mintCollectionNftConfigEventArgs);
         }
         
         #region Configuration Classes
@@ -520,6 +539,26 @@ namespace ChainSafe.Gaming.Marketplace
             public CollectionCreateConfigEventArgs(string bearerToken)
             {
                 BearerToken = bearerToken;
+            }
+            
+            #endregion
+        }
+        
+        public class MintCollectionNftConfigEventArgs : EventArgs
+        {
+            #region Properties
+            
+            public string BearerToken { get; private set; }
+            public string CollectionContractToListFrom { get; private set; }
+
+            #endregion
+    
+            #region Methods
+    
+            public MintCollectionNftConfigEventArgs(string bearerToken, string collectionToListFrom)
+            {
+                BearerToken = bearerToken;
+                CollectionContractToListFrom = collectionToListFrom;
             }
             
             #endregion

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/LoginManagerMarketplace.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/LoginManagerMarketplace.cs
@@ -176,6 +176,8 @@ namespace ChainSafe.Gaming.Marketplace
                 EventManagerMarketplace.RaiseConfigureCollectionCreateManager(collectionCreateConfigArgs);
                 var listNftToMarketplaceCreateConfigArgs = new EventManagerMarketplace.ListNftToMarketplaceConfigEventArgs(loginResponse.access_token.token);
                 EventManagerMarketplace.RaiseConfigureListNftToMarketplaceManager(listNftToMarketplaceCreateConfigArgs);
+                var mintCollectionNftConfigArgs = new EventManagerMarketplace.MintCollectionNftConfigEventArgs(loginResponse.access_token.token, null);
+                EventManagerMarketplace.RaiseMintCollectionNftManager(mintCollectionNftConfigArgs);
             }
         }
         

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/MarketplaceGUIManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/MarketplaceGUIManager.cs
@@ -64,7 +64,7 @@ namespace ChainSafe.Gaming.Marketplace
             createMarketplaceUploadImageButton.onClick.AddListener(UploadMarketplaceImage);
             createCollectionUploadImageButton.onClick.AddListener(UploadCollectionImage);
             mintNftToCollectionMenuButton.onClick.AddListener(ToggleMintNftToCollectionMenu);
-            mintNftToCollectionButton.onClick.AddListener(UploadNftImageToCollection);
+            mintNftToCollectionButton.onClick.AddListener(MintNftToCollection);
             backButtonMintNftToCollection.onClick.AddListener(ToggleMintNftToCollectionMenu);
             listNftToMarketplaceButton.onClick.AddListener(ListNftToMarketplace);
             backButtonListNftToMarketplace.onClick.AddListener(ToggleListNftToMarketplaceMenu);
@@ -215,9 +215,9 @@ namespace ChainSafe.Gaming.Marketplace
         /// <summary>
         /// Uploads marketplace image.
         /// </summary>
-        private void UploadNftImageToCollection()
+        private void MintNftToCollection()
         {
-            EventManagerMarketplace.RaiseUploadNftImageToCollection();
+            EventManagerMarketplace.RaiseMintNftToCollection();
         }
         
         /// <summary>
@@ -226,7 +226,7 @@ namespace ChainSafe.Gaming.Marketplace
         private void ToggleMintNftToCollectionMenu()
         {
             mintNftToCollectionMenu.SetActive(!mintNftToCollectionMenu.activeSelf);
-            EventManagerMarketplace.RaiseToggleMintNftToSelectionMenu();
+            EventManagerMarketplace.RaiseToggleMintNftToCollectionMenu();
         }
 
         /// <summary>

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/MintCollectionNftManager.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK Marketplace/2.6.1/Marketplace Samples/Scripts/MintCollectionNftManager.cs
@@ -21,6 +21,13 @@ namespace ChainSafe.Gaming.Marketplace
 
         #endregion
         
+        #region Properties
+
+        private string CollectionContractToListFrom { get; set; }
+        private string BearerToken { get; set; }
+
+        #endregion
+        
         #region Methods
         
         /// <summary>
@@ -35,10 +42,10 @@ namespace ChainSafe.Gaming.Marketplace
             switch (typeDropDown.options[typeDropDown.value].text)
             {
                 case "721":
-                    Mint721CollectionNft(nameInput.text, descriptionInput.text);
+                    Mint721CollectionNft(BearerToken, CollectionContractToListFrom, nameInput.text, descriptionInput.text);
                     break;
                 case "1155":
-                    Mint1155CollectionNft(nameInput.text, descriptionInput.text, amountInput.text);
+                    Mint1155CollectionNft(BearerToken, CollectionContractToListFrom, nameInput.text, amountInput.text, descriptionInput.text);
                     break;
             }
         }
@@ -46,11 +53,11 @@ namespace ChainSafe.Gaming.Marketplace
         /// <summary>
         /// Mints an NFT to a 721 collection
         /// </summary>
-        public async void Mint721CollectionNft(string collectionContract721, string uri721)
+        public async void Mint721CollectionNft(string bearerToken, string collectionContract721, string name721, string description721)
         {
             try
             {
-                var response = await EvmMarketplace.Mint721CollectionNft(collectionContract721, uri721);
+                var response = await EvmMarketplace.Mint721CollectionNft(bearerToken, collectionContract721, name721, description721);
                 Debug.Log($"TX: {response.TransactionHash}");
             }
             catch (Web3Exception e)
@@ -63,11 +70,11 @@ namespace ChainSafe.Gaming.Marketplace
         /// <summary>
         /// Mints an NFT to a 1155 collection
         /// </summary>
-        public async void Mint1155CollectionNft(string collectionContract1155, string uri1155, string amount1155)
+        public async void Mint1155CollectionNft(string bearerToken, string collectionContract1155, string name1155, string amount1155, string description1155)
         {
             try
             {
-                var response = await EvmMarketplace.Mint1155CollectionNft(collectionContract1155, uri1155, amount1155);
+                var response = await EvmMarketplace.Mint1155CollectionNft(bearerToken, collectionContract1155, name1155, amount1155, description1155);
                 Debug.Log($"TX: {response.TransactionHash}");
             }
             catch (Web3Exception e)
@@ -82,7 +89,8 @@ namespace ChainSafe.Gaming.Marketplace
         /// </summary>
         private void OnEnable()
         {
-            EventManagerMarketplace.UploadNftImageToCollection += UploadNftImage;
+            EventManagerMarketplace.MintNftToCollection += UploadNftImage;
+            EventManagerMarketplace.ConfigureMintCollectionNftManager += OnConfigureMintCollectionNftManager;
         }
         
         /// <summary>
@@ -90,7 +98,22 @@ namespace ChainSafe.Gaming.Marketplace
         /// </summary>
         private void OnDisable()
         {
-            EventManagerMarketplace.UploadNftImageToCollection -= UploadNftImage;
+            EventManagerMarketplace.MintNftToCollection -= UploadNftImage;
+            EventManagerMarketplace.ConfigureMintCollectionNftManager -= OnConfigureMintCollectionNftManager;
+        }
+        
+        /// <summary>
+        /// Configures tokens.
+        /// </summary>
+        /// <param name="sender">Sender.</param>
+        /// <param name="mintCollectionNftConfigEventArgs">Args.</param>
+        private void OnConfigureMintCollectionNftManager(object sender, EventManagerMarketplace.MintCollectionNftConfigEventArgs mintCollectionNftConfigEventArgs)
+        {
+            if (mintCollectionNftConfigEventArgs.BearerToken != null)
+            {
+                BearerToken = mintCollectionNftConfigEventArgs.BearerToken;
+            }
+            CollectionContractToListFrom = mintCollectionNftConfigEventArgs.CollectionContractToListFrom;
         }
         
         #endregion

--- a/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.6.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Marketplace/MarketplaceCalls.cs
+++ b/src/UnitySampleProject/Assets/Samples/web3.unity SDK/2.6.0/Web3.Unity Samples/Scripts/Scenes/SampleMain/Marketplace/MarketplaceCalls.cs
@@ -44,11 +44,15 @@ public class MarketplaceCalls : MonoBehaviour
     [Header("Mint 721 to collection calls")]
     [SerializeField] private string collectionContract721 = "Set 721 collection to mint to";
     [SerializeField] private string uri721 = "Set metadata uri with full path i.e. https://ipfs.chainsafe.io/ipfs/bafyjvzacdj4apx52hvbyjkwyf7i6a7t3pcqd4kw4xxfc67hgvn3a";
+    [SerializeField] private string name721 = "Set Nft name";
+    [SerializeField] private string description721 = "Set Nft description";
 
     [Header("Mint 1155 to collection calls")]
     [SerializeField] private string collectionContract1155 = "Set 1155 collection to mint to";
     [SerializeField] private string uri1155 = "Set metadata uri with full path i.e. https://ipfs.chainsafe.io/ipfs/bafyjvzacdj4apx52hvbyjkwyf7i6a7t3pcqd4kw4xxfc67hgvn3a";
     [SerializeField] private string amount1155 = "Set amount of Nfts to mint i.e 1";
+    [SerializeField] private string name1155 = "Set Nft name";
+    [SerializeField] private string description1155 = "Set Nft description";
 
     [Header("Create marketplace call")]
     [SerializeField] private string marketplaceName = "Set marketplace name";
@@ -185,7 +189,7 @@ public class MarketplaceCalls : MonoBehaviour
     /// </summary>
     public async void Mint721CollectionNft()
     {
-        var response = await Marketplace.Mint721CollectionNft(collectionContract721, uri721);
+        var response = await Marketplace.Mint721CollectionNft(bearerToken, collectionContract721, name721, description721);
         Debug.Log($"TX: {response.TransactionHash}");
     }
 
@@ -194,7 +198,7 @@ public class MarketplaceCalls : MonoBehaviour
     /// </summary>
     public async void Mint1155CollectionNft()
     {
-        var response = await Marketplace.Mint1155CollectionNft(collectionContract1155, uri1155, amount1155);
+        var response = await Marketplace.Mint1155CollectionNft(bearerToken, collectionContract1155, name1155, amount1155, description1155);
         Debug.Log($"TX: {response.TransactionHash}");
     }
 


### PR DESCRIPTION
Closed loading menu if no items are found in collections & marketplaces.
Allowed collections & marketplaces to be created without a description to match the dashboard's flow.
Updated form data string from erc721/1155 to ERC721/1155 as the API had been altered and was causing it to throw.
Optimized & cleaned up some code for better performance.
Removed redundant using directives.
Closes #1066

To Test:
Drop the marketplace prefab into a scene
Login to the SDK and go to the scene with the marketplace prefab

Check conditions:
1. Marketplaces and collections can be created with a blank description.
2. Empty collections and marketplaces should now toggle the loading menu off when opened.