### PR TITLE
Webgl template switch fix

### DIFF
--- a/Packages/io.chainsafe.web3-unity/Editor/WebGLTemplateSync.cs
+++ b/Packages/io.chainsafe.web3-unity/Editor/WebGLTemplateSync.cs
@@ -72,6 +72,21 @@ namespace ChainSafe.GamingSdk.Editor
             {
                 AssetDatabase.AllowAutoRefresh();
                 AssetDatabase.Refresh();
+                SwitchTemplate();
+            }
+        }
+        
+        public static void SwitchTemplate()
+        {
+            var projectSettings = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/ProjectSettings.asset")[0];
+            SerializedObject so = new SerializedObject(projectSettings);
+            SerializedProperty webGLTemplateProp = so.FindProperty("webGLTemplate");
+        
+            if (webGLTemplateProp != null)
+            {
+                webGLTemplateProp.stringValue = "Web3.Unity";
+                so.ApplyModifiedProperties();
+                Debug.Log("WebGL Template changed to Web3.Unity");
             }
         }
 


### PR DESCRIPTION
Switches to the installed WebGL template for an improved UX.
Closes #1138 

To Test:
Swap the build platform over to WebGL and install the templates when prompted.

Expected Result:
WebGL template in build settings for WebGL is automatically swapped to the newly installed template.

![image](https://github.com/user-attachments/assets/75ebab70-3954-4066-a2bf-f8073636ad4f)
