### PR TITLE
Web3Auth WebGL fix

### DIFF
--- a/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Plugins/Web3AuthInjectScripts.jspre
+++ b/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Plugins/Web3AuthInjectScripts.jspre
@@ -2,10 +2,10 @@
 
 Module.InjectExternalScripts = function() {
     const scripts = [
-    "https://cdn.jsdelivr.net/npm/@web3auth/no-modal",
-    "https://cdn.jsdelivr.net/npm/@web3auth/wallet-services-plugin",
-    "https://cdn.jsdelivr.net/npm/@web3auth/openlogin-adapter",
-    "https://cdn.jsdelivr.net/npm/@web3auth/ethereum-provider"
+    "https://cdn.jsdelivr.net/npm/@web3auth/no-modal@9.1.0",
+    "https://cdn.jsdelivr.net/npm/@web3auth/wallet-services-plugin@9.1.0",
+    "https://cdn.jsdelivr.net/npm/@web3auth/openlogin-adapter@8.12.4",
+    "https://cdn.jsdelivr.net/npm/@web3auth/ethereum-provider@9.0.2"
     ];
 
     scripts.forEach(src => {

--- a/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Plugins/Web3AuthWebGLModal.jslib
+++ b/Packages/io.chainsafe.web3-unity.web3auth/Runtime/Plugins/Web3AuthWebGLModal.jslib
@@ -47,7 +47,7 @@ var Web3AuthWebGLNoModal =  {
                 }
             });
         
-            const openloginAdapter = new window.OpenloginAdapter.OpenloginAdapter();
+            const openloginAdapter = new window.OpenloginAdapter.OpenloginAdapter({ privateKeyProvider });
             window.web3auth.configureAdapter(openloginAdapter);
             
             await window.web3auth.init();


### PR DESCRIPTION
closes #1155 
the issue was WebGL updated their JS plugins and added a parameter to constructor. Someone else had the same issue [here](https://web3auth.io/community/t/walletinitializationerror-invalid-params-passed-in-privatekey-provider-is-required-before-initialization/4450/4), we should find a way to enforce older versions if possible, to avoid this in the future.