### PR TITLE
Documentation enforced for PRs to merge

### DIFF
--- a/.github/workflows/documentation_check.yml
+++ b/.github/workflows/documentation_check.yml
@@ -18,4 +18,6 @@ jobs:
         run: echo "Documentation Check Passed"
       - name: Failure
         if: ${{ github.event.label.name != 'documented' }}
-        run: exit 1
+        run: |
+          echo "Documentation Check Failed - Missing 'documented' label on Pull Request"
+          exit 1

--- a/.github/workflows/documentation_check.yml
+++ b/.github/workflows/documentation_check.yml
@@ -1,6 +1,7 @@
 name: Documentation Check 📚
 
 on:
+  workflow_call:
   pull_request:
     branches:
       - main

--- a/.github/workflows/documentation_check.yml
+++ b/.github/workflows/documentation_check.yml
@@ -12,8 +12,10 @@ jobs:
   documentation_check:
     name: Documentation Check 📚
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name != 'documented' }}
     steps:
-      - run: |
-          exit 1
-      - run: echo "Documentation Check Passed"
+      - name: Success
+        if: ${{ github.event.label.name == 'documented' }}
+        run: echo "Documentation Check Passed"
+      - name: Failure
+        if: ${{ github.event.label.name != 'documented' }}
+        run: exit 1

--- a/.github/workflows/documentation_check.yml
+++ b/.github/workflows/documentation_check.yml
@@ -1,0 +1,19 @@
+name: Documentation Check 📚
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    types:
+      - labeled
+
+jobs:
+  documentation_check:
+    name: Documentation Check 📚
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name != 'documented' }}
+    steps:
+      - run: |
+          exit 1
+      - run: echo "Documentation Check Passed"

--- a/.github/workflows/documentation_check.yml
+++ b/.github/workflows/documentation_check.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Success
-        if: ${{ github.event.label.name == 'documented' }}
+        if: ${{ github.event.label.name == 'documented' || contains( github.event.pull_request.labels.*.name, 'documented') }}
         run: echo "Documentation Check Passed"
       - name: Failure
-        if: ${{ github.event.label.name != 'documented' }}
+        if: ${{ github.event.label.name != 'documented' && !contains( github.event.pull_request.labels.*.name, 'documented') }}
         run: |
           echo "Documentation Check Failed - Missing 'documented' label on Pull Request"
           exit 1

--- a/.github/workflows/pull_request_checks_dev.yml
+++ b/.github/workflows/pull_request_checks_dev.yml
@@ -17,3 +17,6 @@ jobs:
     name: Analyze 🧐
     if: ${{ github.event.action == 'ready_for_review' || github.event.label.name == 'ready-to-merge'}}
     uses: ChainSafe/web3.unity/.github/workflows/codeql.yml@main
+  documentation_check:
+    name: Documentation Check 📚
+    uses: ChainSafe/web3.unity/.github/workflows/documentation_check.yml@main

--- a/.github/workflows/pull_request_checks_main.yml
+++ b/.github/workflows/pull_request_checks_main.yml
@@ -48,6 +48,10 @@ jobs:
     uses: ChainSafe/web3.unity/.github/workflows/unity_tests.yml@main
     needs: [ pre_job ]
     secrets: inherit
+  documentation_check:
+    name: Documentation Check 📚
+    uses: ChainSafe/web3.unity/.github/workflows/documentation_check.yml@main
+    needs: [ pre_job ]
   duplicate_samples:
     name: Duplicate Samples 🪞
     if: ${{ github.event.action == 'ready_for_review' || github.event.label.name == 'ready-to-merge'}}

--- a/.github/workflows/pull_request_checks_main.yml
+++ b/.github/workflows/pull_request_checks_main.yml
@@ -13,7 +13,7 @@ jobs:
   check_commit:
     name: Check Commit 📝
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && contains( github.event.pull_request.labels.*.name, 'ready-to-merge') }}
     outputs:
       commit_message: ${{ steps.get_head_commit_message.outputs.HEAD_COMMIT_MESSAGE }}
     steps:
@@ -33,7 +33,7 @@ jobs:
     if: ${{ needs.check_commit.outputs.commit_message == 'Sync Dependencies - Auto Commit' }}
     needs: [ check_commit ]
     steps:
-      - run: echo "..."
+      - run: echo "Proceeding to checks..."
   
   web3_tests:
     name: Web3 tests 🕸

--- a/.github/workflows/push_checks_dev.yml
+++ b/.github/workflows/push_checks_dev.yml
@@ -5,9 +5,34 @@ on:
     branches: [ dev ]
 
 jobs:
+  check_commit:
+    name: Check Last Commit 📝
+    runs-on: ubuntu-latest
+    outputs:
+      commit_message: ${{ steps.get_head_commit_message.outputs.HEAD_COMMIT_MESSAGE }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          lfs: true
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Get Head Commit Message
+        id: get_head_commit_message
+        run: echo "HEAD_COMMIT_MESSAGE=$(git show -s --format=%s)" >> "$GITHUB_OUTPUT"
+
+  pre_job:
+    name: Pre Job 🚀
+    runs-on: ubuntu-latest
+    if: ${{ needs.check_commit.outputs.commit_message != 'Sync Dependencies - Auto Commit' }}
+    needs: [ check_commit ]
+    steps:
+      - run: echo "Proceeding to checks..."
+        
   sync_dependencies:
     name: Sync Dependencies 🔄
     uses: ChainSafe/web3.unity/.github/workflows/sync_dependencies.yaml@main
+    needs: [ pre_job ]
     secrets: inherit
   duplicate_samples:
     name: Duplicate Samples 🪞


### PR DESCRIPTION
If we don't add `documented` label to PRs, PRs can't merge
Can't demo now because CI needs to be on default branch before it shows up in required checks in branch protection rules
closes #1226 
CI will fail, because we're referencing action on main that're on my branch
Here's an example of a successful run https://github.com/ChainSafe/web3.unity/actions/runs/11682472207