### PR TITLE
Sync Branches CI fix

### DIFF
--- a/.github/workflows/duplicate_samples.yaml
+++ b/.github/workflows/duplicate_samples.yaml
@@ -3,25 +3,12 @@ name: Duplicate Samples 🪞
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      arguments:
-        required: false
-        description: 'Run Arguments'
-        type: string
-      configuration:
-        required: true
-        description: 'Run Configuration'
-        default: 'Release'
-        type: choice
-        options:
-          - Release
-          - Debug
       
 jobs:
   setup:
     name: Duplicate Samples 🪞
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-duplicate_samples ${{ github.event.inputs.arguments || '-git:enabled' }} -c ${{ github.event.inputs.configuration || 'Release' }}"
+      arguments: "-d"
     secrets: inherit
     

--- a/.github/workflows/pull_request_checks_dev.yml
+++ b/.github/workflows/pull_request_checks_dev.yml
@@ -9,14 +9,21 @@ on:
       - ready_for_review
 
 jobs:
+  pre_job:
+    name: Pre Job 🚀
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'ready_for_review' || (!github.event.pull_request.draft && contains( github.event.pull_request.labels.*.name, 'ready-to-merge')) }}
+    steps:
+      - run: echo "Proceeding to checks..."
   web3_tests:
     name: Web3 tests 🕸
-    if: ${{ github.event.action == 'ready_for_review' || github.event.label.name == 'ready-to-merge'}}
     uses: ChainSafe/web3.unity/.github/workflows/test.yaml@main
+    needs: [ pre_job ]
   analyze_code:
     name: Analyze 🧐
-    if: ${{ github.event.action == 'ready_for_review' || github.event.label.name == 'ready-to-merge'}}
     uses: ChainSafe/web3.unity/.github/workflows/codeql.yml@main
+    needs: [ pre_job ]
   documentation_check:
     name: Documentation Check 📚
     uses: ChainSafe/web3.unity/.github/workflows/documentation_check.yml@main
+    needs: [ pre_job ]

--- a/.github/workflows/push_checks_main.yml
+++ b/.github/workflows/push_checks_main.yml
@@ -2,13 +2,13 @@ name: Post Push Checks
 
 on:
   push:
-    branches: [ rob/sync-branches-ci-fix ]
+    branches: [ main ]
 
 jobs:
   sync_branches:
     name: Sync Branches ♾️
-    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@rob/sync-branches-ci-fix
+    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@main
     with:
-      base: rob/sync-branches-ci-fix
-      target: rob/sync-branches-ci-fix-test-branch
+      base: main
+      target: dev
     secrets: inherit

--- a/.github/workflows/push_checks_main.yml
+++ b/.github/workflows/push_checks_main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sync_branches:
     name: Sync Branches ♾️
-    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@rob/main
+    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@main
     with:
       base: main
       target: dev

--- a/.github/workflows/push_checks_main.yml
+++ b/.github/workflows/push_checks_main.yml
@@ -11,4 +11,5 @@ jobs:
     with:
       base: main
       target: dev
+      skip_ci: false
     secrets: inherit

--- a/.github/workflows/push_checks_main.yml
+++ b/.github/workflows/push_checks_main.yml
@@ -2,13 +2,13 @@ name: Post Push Checks
 
 on:
   push:
-    branches: [ rob/sync-branches-ci-fix ]
+    branches: [ main ]
 
 jobs:
   sync_branches:
     name: Sync Branches ♾️
-    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@rob/sync-branches-ci-fix
+    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@rob/main
     with:
-      base: rob/sync-branches-ci-fix
-      target: rob/sync-branches-ci-fix-test-branch
+      base: main
+      target: dev
     secrets: inherit

--- a/.github/workflows/push_checks_main.yml
+++ b/.github/workflows/push_checks_main.yml
@@ -2,13 +2,13 @@ name: Post Push Checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ rob/sync-branches-ci-fix ]
 
 jobs:
   sync_branches:
     name: Sync Branches ♾️
-    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@main
+    uses: ChainSafe/web3.unity/.github/workflows/sync_branches.yaml@rob/sync-branches-ci-fix
     with:
-      base: main
-      target: dev
+      base: rob/sync-branches-ci-fix
+      target: rob/sync-branches-ci-fix-test-branch
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Setup job
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-p ${{ github.event.inputs.version }}"
+      arguments: "-r ${{ github.event.inputs.version }}"
     secrets: inherit
   release:
     name: Release job

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Setup job
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-r ${{ github.event.inputs.version }}"
+      arguments: "--deploy ${{ github.event.inputs.version }}"
     secrets: inherit
   release:
     name: Release job

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Setup job
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-release:${{ github.event.inputs.version }}"
+      arguments: "-p ${{ github.event.inputs.version }}"
     secrets: inherit
   release:
     name: Release job

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -48,5 +48,5 @@ jobs:
       - name: Run
         run: |
           cd Setup
-          dotnet run -c ${{ inputs.configuration || github.event.inputs.configuration }} ${{ inputs.arguments || github.event.inputs.arguments }}
+          dotnet run ${{ inputs.arguments || github.event.inputs.arguments }} -c ${{ inputs.configuration || github.event.inputs.configuration }}
           git reset --hard

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -40,6 +40,7 @@ jobs:
           lfs: true
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           submodules: recursive
+          fetch-depth: 100
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -6,12 +6,24 @@ on:
       arguments:
         required: true
         type: string
+      configuration:
+        required: false
+        type: string
+        default: "Release"
   workflow_dispatch: 
     inputs:
       arguments:
         required: true
         description: 'Arguments to pass to the setup script'
         type: string
+      configuration:
+        required: true
+        description: 'Run Configuration'
+        default: 'Release'
+        type: choice
+        options:
+          - Release
+          - Debug
 env:
   git_email: "${{ github.actor }}@users.noreply.github.com"
   git_actor: "${{ github.actor }}"
@@ -36,10 +48,5 @@ jobs:
       - name: Run
         run: |
           cd Setup
-          dotnet run ${{ inputs.arguments || github.event.inputs.arguments }} Setup/Setup.csproj
+          dotnet run -c ${{ inputs.configuration || github.event.inputs.configuration }} ${{ inputs.arguments || github.event.inputs.arguments }}
           git reset --hard
-      - name: Cache
-        uses: actions/cache/save@v4
-        with:
-          path: .git
-          key: ${{ runner.os }}-git

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -9,6 +9,10 @@ on:
       target:
         required: true
         type: string
+      skip_ci:
+        required: true
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       base:
@@ -19,19 +23,30 @@ on:
         required: true
         description: "Target branch to Sync"
         type: string
+      skip_ci:
+        required: true
+        description: "Should push also skip CI"
+        type: boolean
+        default: true
+
+env:
+  message: "Auto Sync with ${{ inputs.base }}"
 
 jobs:
-  setup:
+  sync:
     name: Sync Branches ♾️
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set Automation
+        if: ${{ inputs.skip_ci }}
+        run: $message += " [ skip-ci ]"
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:
           type: now
           from_branch: ${{ inputs.base }}
           target_branch: ${{ inputs.target }}
-          message: Auto Merge [skip ci]
+          message: $message
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -36,7 +36,7 @@ env:
 jobs:
   setup:
     name: Sync Branches ♾️
-    uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
+    uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@rob/sync-branches-ci-fix
     with:
       arguments: "sync -b ${{ env.base }} -t ${{ env.taret }} -s ${{ env.skip_ci }}"
     secrets: inherit

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -52,9 +52,8 @@ jobs:
         run: |
           git config user.email $git_email
           git config user.name $git_actor
+          git status
           git fetch origin ${{ env.base }}
-          git show --summary
-          git pull
           git merge ${{ env.base }} --allow-unrelated-histories
           git push
         shell: bash

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ inputs.skip_ci }}
         run: |
           skip_ci=" [skip-ci]"
-          echo "message+=$skip_ci" >> $GITHUB_ENV
+          echo "message=message+$skip_ci" >> $GITHUB_ENV
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.target }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
         run: |
@@ -49,12 +52,10 @@ jobs:
         run: |
           git config user.email $git_email
           git config user.name $git_actor
-          git branch
-          git fetch origin ${{ env.target }}
-          git checkout ${{ env.target }}
+          git fetch origin ${{ env.base }}
           git log --name-status HEAD^..HEAD
           git pull
-          git merge ${{ env.base }}
+          git merge ${{ env.base }} --allow-unrelated-histories
           git push
         shell: bash
         env:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -31,7 +31,7 @@ on:
 env:
   message: "Auto Sync with ${{ inputs.base }}"
   base: ${{ github.event.inputs.base || inputs.base }}
-  target: ${{ github.event.inputs.target || inputs.target }}"
+  target: ${{ github.event.inputs.target || inputs.target }}
 
 jobs:
   sync:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -53,7 +53,7 @@ jobs:
           git config user.email $git_email
           git config user.name $git_actor
           git fetch origin ${{ env.base }}
-          git log --name-status HEAD^..HEAD
+          git show --summary
           git pull
           git merge ${{ env.base }} --allow-unrelated-histories
           git push

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -28,15 +28,10 @@ on:
         type: boolean
         default: true
 
-env:
-  base: ${{ github.event.inputs.base || inputs.base }}
-  target: ${{ github.event.inputs.target || inputs.target }}
-  skip_ci: ${{ github.event.inputs.skip_ci || inputs.skip_ci }}
-
 jobs:
   setup:
     name: Sync Branches ♾️
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@rob/sync-branches-ci-fix
     with:
-      arguments: "sync -b ${{ env.base }} -t ${{ env.target }} -s ${{ env.skip_ci }}"
+      arguments: "sync -b ${{ github.event.inputs.base || inputs.base }} -t ${{ github.event.inputs.target || inputs.target }} -s ${{ github.event.inputs.skip_ci || inputs.skip_ci }}"
     secrets: inherit

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -47,5 +47,5 @@ jobs:
           type: now
           from_branch: ${{ inputs.base }}
           target_branch: ${{ inputs.target }}
-          message: $message
+          message: ${{ env.message }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -53,8 +53,7 @@ jobs:
           git config user.email $git_email
           git config user.name $git_actor
           git status
-          git checkout ${{ env.base }}
-          git checkout ${{ env.target }}
+          git branch
           git merge ${{ env.base }} --allow-unrelated-histories
           git push
         shell: bash

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,7 +40,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
-        run: echo "message+=' [ skip-ci ]'" >> $GITHUB_ENV
+        run: |
+          skip_ci=" [skip-ci]"
+          echo "message+=$skip_ci" >> $GITHUB_ENV
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -46,10 +46,14 @@ jobs:
           skip_ci=" [skip-ci]"
           echo "message=$message$skip_ci" >> $GITHUB_ENV
       - name: Sync Branches
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          from_branch: ${{ env.base }}
-          target_branch: ${{ env.target }}
-          message: ${{ env.message }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.email $git_email
+          git config user.name $git_actor
+          git checkout ${{ env.target }}
+          git pull
+          git merge ${{ env.base }} --allow-unrelated-histories
+          git push
+        shell: bash
+        env:
+          git_email: "${{ github.actor }}@users.noreply.github.com"
+          git_actor: "${{ github.actor }}"

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
-        run: echo $message += " [ skip-ci ]"
+        run: echo "message+=' [ skip-ci ]'" >> $GITHUB_ENV
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ inputs.skip_ci }}
         run: |
           skip_ci=" [skip-ci]"
-          echo "message=$message+$skip_ci" >> $GITHUB_ENV
+          echo "message=$message$skip_ci" >> $GITHUB_ENV
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
-        run: $message += " [ skip-ci ]"
+        run: message += " [ skip-ci ]"
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -53,7 +53,9 @@ jobs:
           git config user.email $git_email
           git config user.name $git_actor
           git status
-          git branch
+          git fetch origin ${{ env.base }}
+          git checkout ${{ env.base }}
+          git checkout ${{ env.target }}
           git merge ${{ env.base }} --allow-unrelated-histories
           git push
         shell: bash

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -38,5 +38,5 @@ jobs:
     name: Sync Branches ♾️
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-b ${{ env.base }} -t ${{ env.taret }} -s ${{ env.skip_ci }}"
+      arguments: "sync -b ${{ env.base }} -t ${{ env.taret }} -s ${{ env.skip_ci }}"
     secrets: inherit

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -52,8 +52,9 @@ jobs:
           git branch
           git fetch origin ${{ env.target }}
           git checkout ${{ env.target }}
+          git log --name-status HEAD^..HEAD
           git pull
-          git merge ${{ env.base }} --allow-unrelated-histories
+          git merge ${{ env.base }}
           git push
         shell: bash
         env:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ inputs.skip_ci }}
         run: |
           skip_ci=" [skip-ci]"
-          echo "message=message+$skip_ci" >> $GITHUB_ENV
+          echo "message=$message+$skip_ci" >> $GITHUB_ENV
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,7 +40,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
-        run: message += " [ skip-ci ]"
+        run: |
+          $message += " [ skip-ci ]"
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -24,7 +24,7 @@ on:
         type: string
       skip_ci:
         required: true
-        description: "Should push also skip CI"
+        description: "Should push skip CI"
         type: boolean
         default: true
 

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -49,6 +49,8 @@ jobs:
         run: |
           git config user.email $git_email
           git config user.name $git_actor
+          git branch
+          git fetch origin ${{ env.target }}
           git checkout ${{ env.target }}
           git pull
           git merge ${{ env.base }} --allow-unrelated-histories

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -38,5 +38,5 @@ jobs:
     name: Sync Branches ♾️
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@rob/sync-branches-ci-fix
     with:
-      arguments: "sync -b ${{ env.base }} -t ${{ env.taret }} -s ${{ env.skip_ci }}"
+      arguments: "sync -b ${{ env.base }} -t ${{ env.target }} -s ${{ env.skip_ci }}"
     secrets: inherit

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -1,4 +1,4 @@
-name: Sync Branches
+name: Sync Branches ♾️
 
 on:
   workflow_call:
@@ -29,36 +29,14 @@ on:
         default: true
 
 env:
-  message: "Auto Sync with ${{ inputs.base }}"
   base: ${{ github.event.inputs.base || inputs.base }}
   target: ${{ github.event.inputs.target || inputs.target }}
+  skip_ci: ${{ github.event.inputs.skip_ci || inputs.skip_ci }}
 
 jobs:
-  sync:
+  setup:
     name: Sync Branches ♾️
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.target }}
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Set Automation
-        if: ${{ inputs.skip_ci }}
-        run: |
-          skip_ci=" [skip-ci]"
-          echo "message=$message$skip_ci" >> $GITHUB_ENV
-      - name: Sync Branches
-        run: |
-          git config user.email $git_email
-          git config user.name $git_actor
-          git status
-          git fetch origin ${{ env.base }}
-          git checkout ${{ env.base }}
-          git checkout ${{ env.target }}
-          git merge ${{ env.base }} --allow-unrelated-histories
-          git push
-        shell: bash
-        env:
-          git_email: "${{ github.actor }}@users.noreply.github.com"
-          git_actor: "${{ github.actor }}"
+    uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
+    with:
+      arguments: "-b ${{ env.base }} -t ${{ env.taret }} -s ${{ env.skip_ci }}"
+    secrets: inherit

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -30,6 +30,8 @@ on:
 
 env:
   message: "Auto Sync with ${{ inputs.base }}"
+  base: ${{ github.event.inputs.base || inputs.base }}
+  target: ${{ github.event.inputs.target || inputs.base }}"
 
 jobs:
   sync:
@@ -47,7 +49,7 @@ jobs:
         uses: devmasx/merge-branch@master
         with:
           type: now
-          from_branch: ${{ inputs.base }}
-          target_branch: ${{ inputs.target }}
+          from_branch: ${{ env.base }}
+          target_branch: ${{ env.target }}
           message: ${{ env.message }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -40,8 +40,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Set Automation
         if: ${{ inputs.skip_ci }}
-        run: |
-          $message += " [ skip-ci ]"
+        run: echo $message += " [ skip-ci ]"
       - name: Sync Branches
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -31,7 +31,7 @@ on:
 env:
   message: "Auto Sync with ${{ inputs.base }}"
   base: ${{ github.event.inputs.base || inputs.base }}
-  target: ${{ github.event.inputs.target || inputs.base }}"
+  target: ${{ github.event.inputs.target || inputs.target }}"
 
 jobs:
   sync:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -10,7 +10,6 @@ on:
         required: true
         type: string
       skip_ci:
-        required: true
         type: boolean
         default: true
   workflow_dispatch:

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -53,7 +53,8 @@ jobs:
           git config user.email $git_email
           git config user.name $git_actor
           git status
-          git fetch origin ${{ env.base }}
+          git checkout ${{ env.base }}
+          git checkout ${{ env.target }}
           git merge ${{ env.base }} --allow-unrelated-histories
           git push
         shell: bash

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -27,21 +27,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.target }}
-          lfs: true
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
       - name: Sync Branches
-        run: |
-          git config user.email $git_email
-          git config user.name $git_actor
-          git branch --show-current
-          git branch
-          git fetch
-          echo "Syncing branches... base: ${{ inputs.base }} target: ${{ inputs.target }}"
-          git merge ${{ inputs.base }} --allow-unrelated-histories
-          git push
-        shell: bash
-        env:
-          git_email: "${{ github.actor }}@users.noreply.github.com"
-          git_actor: "${{ github.actor }}"
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: ${{ inputs.base }}
+          target_branch: ${{ inputs.target }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -33,4 +33,5 @@ jobs:
           type: now
           from_branch: ${{ inputs.base }}
           target_branch: ${{ inputs.target }}
+          message: Auto Merge [skip ci]
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_dependencies.yaml
+++ b/.github/workflows/sync_dependencies.yaml
@@ -3,25 +3,13 @@ name: Sync Dependencies 🔄
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      arguments:
-        required: false
-        description: 'Run Arguments'
-        type: string
-      configuration:
-        required: true
-        description: 'Run Configuration'
-        default: 'Release'
-        type: choice
-        options:
-          - Release
-          - Debug
     
 jobs:
   setup:
     name: Sync Dependencies 🔄
     uses: ChainSafe/web3.unity/.github/workflows/setup.yaml@main
     with:
-      arguments: "-sync_dependencies ${{ github.event.inputs.arguments || '-git:enabled' }} -c ${{ github.event.inputs.configuration || 'Release' }}"
+      arguments: "-s"
+      configuration: ${{ github.event.inputs.configuration || 'Release' }}
     secrets: inherit
     

--- a/.github/workflows/sync_dependencies.yaml
+++ b/.github/workflows/sync_dependencies.yaml
@@ -3,6 +3,15 @@ name: Sync Dependencies 🔄
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      configuration:
+        required: true
+        description: 'Run Configuration'
+        default: 'Release'
+        type: choice
+        options:
+          - Release
+          - Debug
     
 jobs:
   setup:

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -13,7 +13,7 @@ public class DefaultOptions
     [Option('d', "duplicate_samples", Required = false, Default = false, HelpText = "Duplicate samples in Sample Project into package samples.")]
     public bool DuplicateSamples { get; set; }
     
-    [Option('r', "release", Required = false, HelpText = "Version to release.")]
+    [Option("--deploy", Required = false, HelpText = "Version to release.")]
     public string Release { get; set; }
     
     [Option('g', "git", Required = false, Default = true, HelpText = "Enable Git.")]

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using CommandLine;
+using Setup.Utils;
+
+namespace Setup;
+
+[Verb("do", true, HelpText = "Runs default options.")]
+public class DefaultOptions
+{
+    [Option('s', "sync_dependencies", Required = false, Default = false, HelpText = "Generate and copy dependencies to Sample Project.")]
+    public bool SyncDependencies { get; set; }
+    
+    [Option('d', "duplicate_samples", Required = false, Default = false, HelpText = "Duplicate samples in Sample Project into package samples.")]
+    public bool DuplicateSamples { get; set; }
+    
+    [Option('p', "publish", Required = false, HelpText = "Version to release.")]
+    public string Release { get; set; }
+    
+    [Option('g', "git", Required = false, Default = false, HelpText = "Enable Git.")]
+    public bool Git { get; set; }
+
+    public List<IRunnable> GetRunnableList()
+    {
+        List<IRunnable> runnableList = new List<IRunnable>();
+        
+        if (SyncDependencies)
+        {
+            runnableList.Add(new SyncDependencies());
+        }
+
+        if (DuplicateSamples)
+        {
+            runnableList.Add(new DuplicateSamples());
+        }
+
+        if (!string.IsNullOrEmpty(Release))
+        {
+            runnableList.Add(new Release(Release));
+        }
+
+        runnableList.Add(new Git(Git));
+
+        return runnableList;
+    }
+}

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -13,7 +13,7 @@ public class DefaultOptions
     [Option('d', "duplicate_samples", Required = false, Default = false, HelpText = "Duplicate samples in Sample Project into package samples.")]
     public bool DuplicateSamples { get; set; }
     
-    [Option("--deploy", Required = false, HelpText = "Version to release.")]
+    [Option("deploy", Required = false, HelpText = "Version to release.")]
     public string Release { get; set; }
     
     [Option('g', "git", Required = false, Default = true, HelpText = "Enable Git.")]

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -17,7 +17,7 @@ public class DefaultOptions
     public string Release { get; set; }
     
     [Option('g', "git", Required = false, Default = true, HelpText = "Enable Git.")]
-    public bool Git { get; set; }
+    public bool? EnableGit { get; set; }
 
     public List<IRunnable> GetRunnableList()
     {
@@ -38,7 +38,9 @@ public class DefaultOptions
             runnableList.Add(new Release(Release));
         }
 
-        runnableList.Add(new Git(Git));
+        EnableGit ??= false;
+        
+        runnableList.Add(new Git(EnableGit.Value));
 
         return runnableList;
     }

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -13,7 +13,7 @@ public class DefaultOptions
     [Option('d', "duplicate_samples", Required = false, Default = false, HelpText = "Duplicate samples in Sample Project into package samples.")]
     public bool DuplicateSamples { get; set; }
     
-    [Option('p', "publish", Required = false, HelpText = "Version to release.")]
+    [Option('r', "release", Required = false, HelpText = "Version to release.")]
     public string Release { get; set; }
     
     [Option('g', "git", Required = false, Default = true, HelpText = "Enable Git.")]

--- a/Setup/DefaultOptions.cs
+++ b/Setup/DefaultOptions.cs
@@ -16,7 +16,7 @@ public class DefaultOptions
     [Option('p', "publish", Required = false, HelpText = "Version to release.")]
     public string Release { get; set; }
     
-    [Option('g', "git", Required = false, Default = false, HelpText = "Enable Git.")]
+    [Option('g', "git", Required = false, Default = true, HelpText = "Enable Git.")]
     public bool Git { get; set; }
 
     public List<IRunnable> GetRunnableList()

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -114,6 +114,8 @@ public class Git : IRunnable
         }
         
         Execute(command);
+        
+        Execute("log -1");
     }
     
     public static void Merge(string branch, bool allowUnrelatedHistories = true)

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -22,6 +22,8 @@ public class Git : IRunnable
     public void Run()
     {
         Console.WriteLine($"Git {nameof(Enabled)} : {Enabled}");
+        
+        Execute("status");
     }
 
     private static void Execute(string command)

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -116,10 +116,15 @@ public class Git : IRunnable
         Execute(command);
     }
     
-    public static void Merge(string branch, bool allowUnrelatedHistories = true)
+    public static void Merge(string branch, string message = "", bool allowUnrelatedHistories = true)
     {
-        string command = $"merge {branch}";
+        string command = $"merge {branch} --no-edit --commit --no-ff";
 
+        if (!string.IsNullOrEmpty(message))
+        {
+            command += $" -m \"{message}\"";
+        }
+        
         if (allowUnrelatedHistories)
         {
             command += " --allow-unrelated-histories";

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -114,8 +114,6 @@ public class Git : IRunnable
         }
         
         Execute(command);
-        
-        Execute("log -1");
     }
     
     public static void Merge(string branch, bool allowUnrelatedHistories = true)

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Setup.Utils;
 
 namespace Setup;
@@ -106,9 +107,11 @@ public class Git : IRunnable
     {
         string command = $"checkout {branch}";
 
+        Console.WriteLine(Directory.GetCurrentDirectory());
+        
         if (!string.IsNullOrEmpty(path))
         {
-            command += $" -- \"{path}\"";
+            command += $" \"../{path}\"";
         }
         
         Execute(command);

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -108,7 +108,7 @@ public class Git : IRunnable
 
         if (!string.IsNullOrEmpty(path))
         {
-            command += $" \"{path}\"";
+            command += $" \"{path}.\"";
         }
         
         Execute(command);

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -118,7 +118,7 @@ public class Git : IRunnable
     {
         Execute("reset --hard");
         
-        Execute("git status");
+        Execute("status");
         
         string command = $"merge {branch}";
 

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -116,10 +116,6 @@ public class Git : IRunnable
     
     public static void Merge(string branch, bool allowUnrelatedHistories = true)
     {
-        Execute("reset --hard");
-        
-        Execute("status");
-        
         string command = $"merge {branch}";
 
         if (allowUnrelatedHistories)

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -114,7 +114,7 @@ public class Git : IRunnable
         Execute(command);
     }
     
-    public static void Merge(string branch, bool allowUnrelatedHistories = false)
+    public static void Merge(string branch, bool allowUnrelatedHistories = true)
     {
         string command = $"merge {branch}";
 

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using Setup.Utils;
 
 namespace Setup;
@@ -107,11 +106,9 @@ public class Git : IRunnable
     {
         string command = $"checkout {branch}";
 
-        Console.WriteLine(Directory.GetCurrentDirectory());
-        
         if (!string.IsNullOrEmpty(path))
         {
-            command += $" \"../{path}\"";
+            command += $" \"{path}\"";
         }
         
         Execute(command);

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Setup.Utils;
 
 namespace Setup;
@@ -8,46 +6,61 @@ namespace Setup;
 /// <summary>
 /// Git helper class.
 /// </summary>
-public static class Git
+public class Git : IRunnable
 {
     private static bool _configured;
 
-    public static bool Enabled { get; private set; } = true;
+    public static bool Enabled { get; private set; }
 
-    public static void Configure(string configuration)
+    public int Order => - 1;
+
+    public Git(bool enabled)
     {
-        switch (configuration)
+        Enabled = enabled;
+    }
+    
+    public void Run()
+    {
+        Console.WriteLine($"Git {nameof(Enabled)} : {Enabled}");
+    }
+
+    private static void Execute(string command)
+    {
+        if (!Enabled)
         {
-            case "enabled":
-                Enabled = true;
-                break;
-            case "disabled":
-                Enabled = false;
-                break;
-            default:
-                throw new Exception($"-git can't configure {configuration}");
+            Console.WriteLine($"Git disabled skipping command: {command}");
+        }
+        else
+        {
+            if (!_configured)
+            {
+                "git config user.email $git_email".Run();
+                
+                "git config user.name $git_actor".Run();
+
+                _configured = true;
+            }
+        
+            $"git {command}".Run();
         }
     }
     
     public static void Add(string path)
     {
-        $"git add \"{path}\" -f".Run();
+        Execute($"add \"{path}\" -f");
     }
     
-    public static void Commit(string message, string[] tags = null, bool skipCi = true)
+    public static void Commit(string message, string[] tags = null, bool skipCi = true, bool allowEmpty = false)
     {
-        if (!_configured)
-        {
-            Configure();
-        }
-
         if (skipCi)
         {
             message += " [skip ci]";
         }
-        
-        // Checks if there are any changes to commit before committing
-        $"git diff-index --cached --quiet HEAD || git commit -m \"{message}\"".Run();
+
+        Execute(allowEmpty
+            ? $"commit --allow-empty -m \"{message}\""
+            // Checks if there are any changes to commit before committing
+            : $"diff-index --cached --quiet HEAD || git commit -m \"{message}\"");
 
         if (tags != null)
         {
@@ -63,7 +76,7 @@ public static class Git
     
     public static void Push(string[] tags = null)
     {
-        "git push -f".Run();
+        Execute("push -f");
 
         if (tags != null)
         {
@@ -71,7 +84,7 @@ public static class Git
             {
                 if (!string.IsNullOrEmpty(tag))
                 {
-                    $"git push origin \"{tag}\"".Run();
+                    Execute($"push origin \"{tag}\"");
                 }
             }
         }
@@ -83,17 +96,38 @@ public static class Git
         
         Push(tags);
     }
+
+    public static void Fetch(string branch)
+    {
+        Execute($"fetch origin {branch}");
+    }
+    
+    public static void Checkout(string branch, string path = "")
+    {
+        string command = $"checkout {branch}";
+
+        if (!string.IsNullOrEmpty(path))
+        {
+            command += $" \"{path}\"";
+        }
+        
+        Execute(command);
+    }
+    
+    public static void Merge(string branch, bool allowUnrelatedHistories = false)
+    {
+        string command = $"merge {branch}";
+
+        if (allowUnrelatedHistories)
+        {
+            command += " --allow-unrelated-histories";
+        }
+        
+        Execute(command);
+    }
     
     public static void Tag(string tag)
     {
-        $"git tag \"{tag}\"".Run();
-    }
-    
-    private static void Configure()
-    {
-        "git config user.email $git_email".Run();
-        "git config user.name $git_actor".Run();
-
-        _configured = true;
+        Execute($"tag \"{tag}\"");
     }
 }

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -116,6 +116,10 @@ public class Git : IRunnable
     
     public static void Merge(string branch, bool allowUnrelatedHistories = true)
     {
+        Execute("reset --hard");
+        
+        Execute("git status");
+        
         string command = $"merge {branch}";
 
         if (allowUnrelatedHistories)

--- a/Setup/Git.cs
+++ b/Setup/Git.cs
@@ -108,7 +108,7 @@ public class Git : IRunnable
 
         if (!string.IsNullOrEmpty(path))
         {
-            command += $" \"{path}.\"";
+            command += $" -- \"{path}\"";
         }
         
         Execute(command);

--- a/Setup/Setup.cs
+++ b/Setup/Setup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using CommandLine;
 using Newtonsoft.Json;
 using Setup.Utils;
 
@@ -57,35 +58,20 @@ namespace Setup
         {
             List<IRunnable> runnableList = new List<IRunnable>();
             
-            // Parse arguments and Run operations based on that.
-            foreach (var arg in args)
-            {
-                switch (arg)
+            Parser.Default.ParseArguments<DefaultOptions, SyncBranches>(args)
+                .WithParsed(options =>
                 {
-                    case not null when arg.StartsWith("-release"):
-                        
-                        string version = arg.Split(":")[1];
-                        runnableList.AddRunnable(new Release(version));
-                        break;
-                    
-                    case "-duplicate_samples":
-                        runnableList.AddRunnable(new DuplicateSamples());
-                        break;
-                    
-                    case "-sync_dependencies":
-                        runnableList.AddRunnable(new SyncDependencies());
-                        break;
-                    
-                    case not null when arg.StartsWith("-git"):
-                        
-                        string configuration = arg.Split(":")[1];
-                        Git.Configure(configuration);
-                        continue;
-                    
-                    default:
-                        continue;
-                }
-            }
+                    switch (options)
+                    {
+                        case DefaultOptions defaultOptions:
+                            runnableList.AddRange(defaultOptions.GetRunnableList());
+                            break;
+                        case SyncBranches syncBranches:
+                            runnableList.Add(syncBranches);
+                            runnableList.Add(new Git(true));
+                            break;
+                    }
+                });
 
             return runnableList;
         }

--- a/Setup/Setup.csproj
+++ b/Setup/Setup.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.5" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="System.Management.Automation" Version="7.4.5" />

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,9 +49,9 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        $"git log {Base} --oneline -n 3".Run();
+        $"git rev-list --count {Base}".Run();
         
-        $"git log {Target} --oneline -n 3".Run();
+        $"git rev-list --count {Target}".Run();
         
         foreach (string path in _excludedPaths)
         {

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,10 +49,6 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        "git pull -f".Run();
-        
-        $"git rev-list --count {Target}".Run();
-        
         foreach (string path in _excludedPaths)
         {
             Git.Checkout(Base, path);

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -32,7 +32,7 @@ public class SyncBranches : IRunnable
     {
         Dependency[] dependencies = JsonConvert.DeserializeObject<Dependency[]>(File.ReadAllText("dependencies.json"));
 
-        _excludedPaths = Array.ConvertAll(dependencies, d => d.Path);
+        _excludedPaths = Array.ConvertAll(dependencies, d => $"../{d.Path}");
     }
     
     public void Run()

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,7 +49,7 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        $"git rev-list --count {Base}".Run();
+        "git pull -f".Run();
         
         $"git rev-list --count {Target}".Run();
         

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,11 +49,9 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        $"git rev-list --count {Target}..{Base}".Run();
+        $"git log {Base} -n 3".Run();
         
-        "git log -5".Run();
-        
-        $"git rev-list --count {Base}..{Target}".Run();
+        $"git log {Target} -n 3".Run();
         
         foreach (string path in _excludedPaths)
         {

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,14 +49,14 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        // foreach (string path in _excludedPaths)
-        // {
-        //     Git.Checkout(Base, path);
-        //     
-        //     Git.Add(path);
-        // }
-        //
-        // Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
+        foreach (string path in _excludedPaths)
+        {
+            Git.Checkout(Base, path);
+            
+            Git.Add(path);
+        }
+        
+        Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
         
         Git.Merge(Base);
         

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,14 +49,14 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        foreach (string path in _excludedPaths)
-        {
-            Git.Checkout(Base, path);
-            
-            Git.Add(path);
-        }
-        
-        Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
+        // foreach (string path in _excludedPaths)
+        // {
+        //     Git.Checkout(Base, path);
+        //     
+        //     Git.Add(path);
+        // }
+        //
+        // Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
         
         Git.Merge(Base);
         

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,9 +49,9 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        $"git log {Base} -n 3".Run();
+        $"git log {Base} --oneline -n 3".Run();
         
-        $"git log {Target} -n 3".Run();
+        $"git log {Target} --oneline -n 3".Run();
         
         foreach (string path in _excludedPaths)
         {

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -57,10 +57,15 @@ public class SyncBranches : IRunnable
         }
         
         Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
+
+        string message = $"Sync to {Base} - Auto Commit";
+
+        if (SkipCi.Value)
+        {
+            message += " [skip ci]";
+        }
         
-        Git.Merge(Base);
-        
-        Git.Commit($"Sync to {Base} - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
+        Git.Merge(Base, message);
         
         Git.Push();
         

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,6 +49,12 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
+        Git.Checkout(Base);
+        
+        Git.Merge(Target, $"Sync to {Target} - Auto Commit");
+        
+        Git.Checkout(Target);
+        
         foreach (string path in _excludedPaths)
         {
             Git.Checkout(Base, path);

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -51,6 +51,10 @@ public class SyncBranches : IRunnable
         
         $"git rev-list --count {Target}..{Base}".Run();
         
+        "git log -5".Run();
+        
+        $"git rev-list --count {Base}..{Target}".Run();
+        
         foreach (string path in _excludedPaths)
         {
             Git.Checkout(Base, path);

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,6 +49,8 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
+        $"git rev-list --count {Target}..{Base}".Run();
+        
         foreach (string path in _excludedPaths)
         {
             Git.Checkout(Base, path);

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -49,12 +49,6 @@ public class SyncBranches : IRunnable
         
         Git.Checkout(Target);
         
-        Git.Checkout(Base);
-        
-        Git.Merge(Target, $"Sync to {Target} - Auto Commit");
-        
-        Git.Checkout(Target);
-        
         foreach (string path in _excludedPaths)
         {
             Git.Checkout(Base, path);

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -10,7 +10,7 @@ namespace Setup;
 /// <summary>
 /// Sync branches (merge).
 /// </summary>
-[Verb("sync_branches", HelpText = "Sync branches.")]
+[Verb("sync", HelpText = "Sync branches.")]
 public class SyncBranches : IRunnable
 {
     public int Order => 0;

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CommandLine;
+using Newtonsoft.Json;
+using Setup.Utils;
+
+namespace Setup;
+
+/// <summary>
+/// Sync branches (merge).
+/// </summary>
+[Verb("sync_branches", HelpText = "Sync branches.")]
+public class SyncBranches : IRunnable
+{
+    public int Order => 0;
+    
+    public IEnumerable<string> CommandLineArgument { get; set; }
+
+    private readonly string[] _excludedPaths;
+
+    [Option('b', "base", Required = true, HelpText = "Base branch.")]
+    public string Base { get; set; }
+    
+    [Option('t', "target", Required = true, HelpText = "Target branch.")]
+    public string Target { get; set; }
+    
+    [Option('s', "skip_ci", Required = false, Default = true, HelpText = "Disable/Skip CI triggers for sync/merge.")]
+    public bool SkipCi { get; set; }
+    
+    public SyncBranches()
+    {
+        Dependency[] dependencies = JsonConvert.DeserializeObject<Dependency[]>(File.ReadAllText("dependencies.json"));
+
+        _excludedPaths = Array.ConvertAll(dependencies, d => d.Path);
+    }
+    
+    public void Run()
+    {
+        Console.WriteLine($"Syncing {Target} branch to {Base} branch...");
+        
+        Git.Fetch(Base);
+        
+        Git.Checkout(Base);
+        
+        Git.Fetch(Target);
+        
+        Git.Checkout(Target);
+        
+        foreach (string path in _excludedPaths)
+        {
+            Git.Checkout(Base, path);
+            
+            Git.Add(path);
+        }
+        
+        Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi, allowEmpty: true);
+        
+        Git.Merge(Base);
+        
+        Git.Commit($"Sync to {Base} - Auto Commit", skipCi: SkipCi, allowEmpty: true);
+        
+        Git.Push();
+        
+        Console.WriteLine($"Synced {Target} branch to {Base} branch completed.");
+    }
+}

--- a/Setup/SyncBranches.cs
+++ b/Setup/SyncBranches.cs
@@ -26,7 +26,7 @@ public class SyncBranches : IRunnable
     public string Target { get; set; }
     
     [Option('s', "skip_ci", Required = false, Default = true, HelpText = "Disable/Skip CI triggers for sync/merge.")]
-    public bool SkipCi { get; set; }
+    public bool? SkipCi { get; set; }
     
     public SyncBranches()
     {
@@ -37,6 +37,8 @@ public class SyncBranches : IRunnable
     
     public void Run()
     {
+        SkipCi ??= false;
+        
         Console.WriteLine($"Syncing {Target} branch to {Base} branch...");
         
         Git.Fetch(Base);
@@ -54,11 +56,11 @@ public class SyncBranches : IRunnable
             Git.Add(path);
         }
         
-        Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi, allowEmpty: true);
+        Git.Commit("Exclude Paths - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
         
         Git.Merge(Base);
         
-        Git.Commit($"Sync to {Base} - Auto Commit", skipCi: SkipCi, allowEmpty: true);
+        Git.Commit($"Sync to {Base} - Auto Commit", skipCi: SkipCi.Value, allowEmpty: true);
         
         Git.Push();
         

--- a/Setup/SyncDependencies.cs
+++ b/Setup/SyncDependencies.cs
@@ -5,6 +5,9 @@ using Setup.Utils;
 
 namespace Setup;
 
+/// <summary>
+/// Generate and copy dependencies to Sample Project.
+/// </summary>
 public class SyncDependencies : IRunnable
 {
     public int Order => 0;

--- a/Setup/Utils/Utilities.cs
+++ b/Setup/Utils/Utilities.cs
@@ -11,16 +11,6 @@ public static class Utilities
 {
     public static void Run(this string command)
     {
-        if (!Git.Enabled)
-        {
-            if (command.ToLower().StartsWith("git"))
-            {
-                Console.WriteLine($"Git disabled skipping command: {command}");
-            
-                return;
-            }
-        }
-        
         // Tried switch statement couldn't find a way to make it work
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/Setup/Utils/Utilities.cs
+++ b/Setup/Utils/Utilities.cs
@@ -11,6 +11,8 @@ public static class Utilities
 {
     public static void Run(this string command)
     {
+        Console.WriteLine($"Running Command {command}...");
+        
         // Tried switch statement couldn't find a way to make it work
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
@@ -27,8 +29,8 @@ public static class Utilities
             throw new Exception($"[Unsupported OS] Can't run command: {command}");
         }
     }
-    
-    public static void RunWithPowershell(this string command)
+
+    private static void RunWithPowershell(this string command)
     {
         using (PowerShell powerShell = PowerShell.Create())
         {
@@ -52,7 +54,7 @@ public static class Utilities
     /// </summary>
     /// <param name="command">Command to run.</param>
     /// <exception cref="Exception">If command fails.</exception>
-    public static void RunWithBash( this string command)
+    private static void RunWithBash( this string command)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/Setup/Utils/Utilities.cs
+++ b/Setup/Utils/Utilities.cs
@@ -11,7 +11,7 @@ public static class Utilities
 {
     public static void Run(this string command)
     {
-        Console.WriteLine($"Running Command {command}...");
+        Console.WriteLine($"Running Command : {command}");
         
         // Tried switch statement couldn't find a way to make it work
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -14,6 +14,6 @@ if "%1"=="" (
     set "config=%1"
 )
 
-dotnet run -sync_dependencies -git:disabled -c %config% Setup.csproj
+dotnet run -s -g false -c %config% Setup.csproj
 
 popd

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,6 @@ git submodule update --init
 pushd "$scripts_dir"/../Setup
 
 # publish DLLs to unity package
-dotnet run -sync_dependencies -git:disabled -c ${1:-Release} Setup.csproj
+dotnet run -s -g false -c ${1:-Release}
 
 popd


### PR DESCRIPTION
- Fixes merging main to dev automatically
- What it does is basically whenever we push to main it tries and merge it to dev (sync both branches)
- we're using Setup.sln
~- Note :- It doesn't resolve conflicts and we're likely to run into them since we're updating dependencies via CI on both branches so at the very least library folders with dlls will have conflict~ Now we got an exclusion path list
- Improved command line parsing for adding new option in Setup.sln
- Updated label checks in PR to dev to work on simultaneous labeling
- as usual CI won't work till this is on main but [here's](https://github.com/ChainSafe/web3.unity/actions/runs/12069815356/job/33657900672) a successful test run