### PR TITLE
Updating github actions cache version

### DIFF
--- a/.github/workflows/unity_tests.yml
+++ b/.github/workflows/unity_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Start Anvil
       run: |
         anvil --host 0.0.0.0 --fork-url https://rpc.ankr.com/eth_sepolia --mnemonic "test test test test test test test test test test test junk" &
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ matrix.projectPath }}/Library
         key: Library-${{ matrix.projectPath }}


### PR DESCRIPTION
Updating actions cache version to v4 as v2 is being deprecated shortly.

No documentation changes are needed in this PR.