### PR TITLE
docs: fix XML documentation and remove TODO comments

### DIFF
--- a/src/ChainSafe.Gaming.Unity/UnityLogWriter.cs
+++ b/src/ChainSafe.Gaming.Unity/UnityLogWriter.cs
@@ -27,7 +27,7 @@ namespace ChainSafe.Gaming.Web3.Unity
         }
 
         /// <summary>
-        /// Logs the message to Unity's console as a  Debug LogError message.
+        /// Logs the message to Unity's console as a Debug.LogError message.
         /// </summary>
         /// <param name="message">message to show.</param>
         public void LogError(string message)

--- a/src/ChainSafe.Gaming/Web3/Core/Chains/IChainConfig.cs
+++ b/src/ChainSafe.Gaming/Web3/Core/Chains/IChainConfig.cs
@@ -3,7 +3,7 @@ namespace ChainSafe.Gaming.Web3
     /// <summary>
     /// Configuration object containing chain settings.
     /// </summary>
-    public interface IChainConfig // TODO: double check these xml docs pls
+    public interface IChainConfig
     {
         /// <summary>
         /// The id of the chain to be used. Equals '1' for Ethereum Mainnet.
@@ -31,7 +31,7 @@ namespace ChainSafe.Gaming.Web3
         public string Rpc { get; }
 
         /// <summary>
-        /// TODO.
+        /// The WebSocket URI for the chain, used for real-time blockchain event subscriptions.
         /// </summary>
         public string Ws { get; }
 


### PR DESCRIPTION
## PR Description:

* Fix double space typo in [\chainsafe\web3.unity\tree\main\src\ChainSafe.Gaming.Unity\UnityLogWriter.cs](vscode-file://vscode-app/c:/Users/HomePC/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) XML comment
* Add proper documentation for IChainConfig.Ws property
* Remove outdated TODO comment from IChainConfig interface